### PR TITLE
Badges pointing to respective Actions runs page

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,8 @@ Arm CMSIS Solution works as a standalone tool and can also interact with other V
 - [clangd](https://marketplace.visualstudio.com/items?itemName=llvm-vs-code-extensions.vscode-clangd): Adds smart features to the VS Code editor, including code completion, compile errors, and go-to-definition.
 
 ## Feature overview
-
 ![CMSIS Solution Quick Tutorial](https://mdk-packs.github.io/vscode-cmsis-solution-docs/videos/MDK6_Productivity.gif)
-
-For detailed information refer to [User Interface](https://mdk-packs.github.io/vscode-cmsis-solution-docs/userinterface.html) in the CMSIS Solution documentation.
+For detailed information, refer to [User Interface](https://mdk-packs.github.io/vscode-cmsis-solution-docs/userinterface.html) in the CMSIS Solution documentation.
 
 ## CMSIS view
 


### PR DESCRIPTION
## Changes
- With these changes, Badges  shall point to the Actions run page (On the default branch)
- Currently, when we click on badge it shows 
<img width="357" height="127" alt="image" src="https://github.com/user-attachments/assets/00e32eb4-6d71-4c19-ad7f-71e030c88128" />


## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [x] 🤖 This change is covered by unit tests (if applicable).
- [x] 🤹 Manual testing has been performed (if necessary).
- [x] 🛡️ Security impacts have been considered (if relevant).
- [x] 📖 Documentation updates are complete (if required).
- [x] 🧠 Third-party dependencies and TPIP updated (if required).
