### PR TITLE
Update `clangd-manager` to make use of `compile_macros.h`

### DIFF
--- a/src/solutions/clangd-manager.test.ts
+++ b/src/solutions/clangd-manager.test.ts
@@ -15,7 +15,6 @@
  */
 
 import 'jest';
-import * as fs from 'fs';
 import * as path from 'path';
 import dedent from 'dedent';
 import { setContext as setContextImport } from '@eclipse-cdt-cloud/clangd-contexts';
@@ -303,10 +302,9 @@ describe('ClangdManager', () => {
         mockConfigurationProvider.setConfigVariable.mockReturnValue(Promise.resolve());
         const csolution = mockSolutionManager.getCsolution();
         csolution!.getContextDescriptors = jest.fn().mockReturnValue([activeContexts[0]]);
+        mockFs.exists.mockResolvedValue(true);
 
         const compileMacrosFile = path.join(path.dirname(activeContexts[0].projectPath!), 'out', 'compile_macros.h');
-        fs.mkdirSync(path.dirname(compileMacrosFile), { recursive: true });
-        fs.writeFileSync(compileMacrosFile, '// macros');
 
         mockSolutionManager.onUpdatedCompileCommandsEmitter.fire();
         await waitTimeout();
@@ -316,7 +314,5 @@ describe('ClangdManager', () => {
         expect(writtenPath).toEqual(expect.lowercaseEquals(path.join(path.dirname(activeContexts[0].projectPath!), '.clangd')));
         expect(writtenContent).toContain('-include');
         expect(writtenContent.toLowerCase()).toContain(compileMacrosFile.toLowerCase());
-
-        fs.rmSync(compileMacrosFile, { recursive: true, force: true });
     });
 });

--- a/src/solutions/clangd-manager.ts
+++ b/src/solutions/clangd-manager.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import * as fs from 'fs';
 import * as path from 'path';
 import * as manifest from '../manifest';
 import * as vscode from 'vscode';
@@ -214,12 +213,13 @@ export class ClangdManager {
 
         // Modify the .clangd file AddFlags for each context guarded on toolchain
         if (clangdFilePath) {
-            if (compileCommandsFileDirectory && fs.existsSync(this.compileMacrosFileURI(compileCommandsFileDirectory).fsPath)) {
+            const compileMacrosFile = compileCommandsFileDirectory ? this.compileMacrosFileURI(compileCommandsFileDirectory) : undefined;
+            if (compileMacrosFile && await this.workspaceFsProvider.exists(compileMacrosFile.fsPath)) {
                 // use compile_macros.h if it is available
                 updatePromises.push(
                     this.generateContextAddCompileMacros(
                         URI.file(clangdFilePath),
-                        this.compileMacrosFileURI(compileCommandsFileDirectory),
+                        compileMacrosFile,
                     )
                 );
             } else if (compileCommandsFileDirectory && (compilerInContext === 'AC6')) {
@@ -257,11 +257,11 @@ export class ClangdManager {
     }
 
     /**
-        * Generate and set Add flags for a context's .clangd file to pre-include compile_macros.h.
-        *
-        * @param clangdFile URI of the context .clangd file to update.
-        * @param compileMacrosFile URI of compile_macros.h to include.
-        * @returns the flags written to CompileFlags.Add.
+     * Generate and set Add flags for a context's .clangd file to pre-include compile_macros.h.
+     *
+     * @param clangdFile URI of the context .clangd file to update.
+     * @param compileMacrosFile URI of compile_macros.h to include.
+     * @returns the flags written to CompileFlags.Add.
      */
     private async generateContextAddCompileMacros(clangdFile: URI, compileMacrosFile: URI): Promise<string[]> {
         // Update clangd AddFlags flags for intellisense uplift


### PR DESCRIPTION
## Fixes
<!-- List the GitHub issue this PR resolves -->
- https://github.com/Open-CMSIS-Pack/vscode-cmsis-solution/issues/26
- Depends on https://github.com/Open-CMSIS-Pack/devtools/issues/2228

## Changes
<!-- List the changes this PR introduces -->
- clangd pre-includes `compile_macros.h` when it is available, otherwise it falls back to the previous mechanism.

## Screenshots
<!-- Show UI changes with screenshots to ease UX/UI feedback: -->

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [x] 🤖 This change is covered by unit tests (if applicable).
- [x] 🤹 Manual testing has been performed (if necessary).
- [x] 🛡️ Security impacts have been considered (if relevant).
- [x] 📖 Documentation updates are complete (if required).
- [x] 🧠 Third-party dependencies and TPIP updated (if required).
