### PR TITLE
Fix unstable test for glob file match

### DIFF
--- a/src/solutions/active-solution-tracker.test.ts
+++ b/src/solutions/active-solution-tracker.test.ts
@@ -106,7 +106,7 @@ describe('ActiveSolutionTracker', () => {
     });
 
     it('uses the configured glob pattern for searches', async () => {
-        const testGlobPattern = faker.word.words();
+        const testGlobPattern = `**/${faker.system.commonFileName()}`;
         configurationProvider.getConfigVariable.mockImplementation((name: string) => name === manifest.CONFIG_EXCLUDE ? testGlobPattern : undefined);
 
         await activeSolutionTracker.activate(context as unknown as vscode.ExtensionContext);
@@ -125,7 +125,7 @@ describe('ActiveSolutionTracker', () => {
         expect(configurationProvider.onChangeConfiguration).toHaveBeenCalledTimes(1);
         expect(configurationProvider.onChangeConfiguration).toHaveBeenCalledWith(expect.any(Function), manifest.CONFIG_EXCLUDE);
 
-        const testGlobPattern = faker.word.words();
+        const testGlobPattern = `**/${faker.system.commonFileName()}`;
         configurationProvider.getConfigVariable.mockImplementation((name: string) => name === manifest.CONFIG_EXCLUDE ? testGlobPattern : undefined);
         configurationProvider.onChangeConfiguration.mock.calls[0][0]();
         await waitTimeout();


### PR DESCRIPTION
## Fixes
<!-- List the GitHub issue this PR resolves -->
- intermittently failing CI tests for ActiveSolutionTracker

## Changes
<!-- List the changes this PR introduces -->
- use faker.system.commonFileName() instead of faker.word.words


## Screenshots
<!-- Show UI changes with screenshots to ease UX/UI feedback: -->

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [x] 🤖 This change is covered by unit tests (if applicable).
- [x] 🤹 Manual testing has been performed (if necessary).
- [x] 🛡️ Security impacts have been considered (if relevant).
- [x] 📖 Documentation updates are complete (if required).
- [x] 🧠 Third-party dependencies and TPIP updated (if required).
