### PR TITLE
Suppress clangd diagnostics in output directory

### DIFF
--- a/src/solutions/clangd-manager.test.ts
+++ b/src/solutions/clangd-manager.test.ts
@@ -229,6 +229,7 @@ describe('ClangdManager', () => {
     it('loads clangd context from workspace state', async () => {
         mockConfigurationProvider.getConfigVariable.mockReturnValue(true);
         mockConfigurationProvider.setConfigVariable.mockReturnValue(Promise.resolve());
+        mockFs.exists.mockResolvedValue(false);
 
         const solutionPath = mockSolutionManager!.getCsolution()!.solutionPath;
         stubWorkspaceState.update(clangDActiveContextKey, {
@@ -250,6 +251,18 @@ describe('ClangdManager', () => {
         expect(state).toBeDefined();
         expect(solutionPath in state!).toBeTruthy();
         expect(state![solutionPath]).toEqual(activeContexts[1].projectPath);
+
+        const diagnosticsSuppress = 'Diagnostics:\n  Suppress: [\'*\']';
+        const expectedOutDir1 = mockSolutionManager.getCsolution()?.cbuildIdxFile?.cbuildFiles?.get(activeContexts[0].projectName)?.outDir;
+        const expectedOutDir2 = mockSolutionManager.getCsolution()?.cbuildIdxFile?.cbuildFiles?.get(activeContexts[1].projectName)?.outDir;
+        expect(mockFs.writeUtf8File).toHaveBeenCalledWith(
+            expect.lowercaseEquals(path.join(expectedOutDir1!, '.clangd')),
+            diagnosticsSuppress,
+        );
+        expect(mockFs.writeUtf8File).toHaveBeenCalledWith(
+            expect.lowercaseEquals(path.join(expectedOutDir2!, '.clangd')),
+            diagnosticsSuppress,
+        );
     });
 
     it('set default clangd context if context in workspace state is invalid', async () => {

--- a/src/solutions/clangd-manager.ts
+++ b/src/solutions/clangd-manager.ts
@@ -171,7 +171,7 @@ export class ClangdManager {
         const state = this.workspaceState;
         if (solutionPath in state) {
             const context = state[solutionPath];
-            csolution?.getContextDescriptors()?.forEach(c => this.setClangdConfigDiagnosticsSuppress(c));
+            csolution?.getContextDescriptors()?.forEach(async c => await this.setClangdConfigDiagnosticsSuppress(c));
             if (csolution?.getContextDescriptors()?.some(c => c.projectPath === context)) {
                 this.globalContext = context;
                 return;


### PR DESCRIPTION
## Fixes
<!-- List the GitHub issue this PR resolves -->
- Related to https://github.com/Open-CMSIS-Pack/vscode-cmsis-solution/issues/26
- Reported by @jkrech: clangd shows redefinition warnings when `compile_macros.h` is opened in the editor
(clangd version 21.1.8 - not reproducible with version 16)
<img width="1136" height="497" alt="image" src="https://github.com/user-attachments/assets/89e0fd92-9073-4db3-9303-8023bc593718" />

## Changes
<!-- List the changes this PR introduces -->
- Ensure a .clangd is present in output directory to suppress diagnostics.
```yml
Diagnostics:
  Suppress: ['*']
```

## Screenshots
<!-- Show UI changes with screenshots to ease UX/UI feedback: -->

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [x] 🤖 This change is covered by unit tests (if applicable).
- [x] 🤹 Manual testing has been performed (if necessary).
- [x] 🛡️ Security impacts have been considered (if relevant).
- [x] 📖 Documentation updates are complete (if required).
- [x] 🧠 Third-party dependencies and TPIP updated (if required).
