### PR TITLE
[Devcontainer]: Sanitize dynamic Docker image tag in workflow

### DIFF
--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -16,9 +16,6 @@ concurrency:
 permissions:
   contents: read
 
-env:
-  image_tag: devcontainer:${{ github.head_ref || github.run_id }}
-
 jobs:
   build:
     name: Build
@@ -43,11 +40,21 @@ jobs:
           dockerfile: .devcontainer/ubuntu-24.04/Dockerfile
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+      - name: Prepare image tag
+        shell: bash
+        run: |
+          RAW_TAG="${GITHUB_HEAD_REF:-$GITHUB_RUN_ID}"
+          SAFE_TAG=$(echo "$RAW_TAG" | tr '/' '-' | tr '[:upper:]' '[:lower:]')
+          echo "image_tag=devcontainer:${SAFE_TAG}" >> "$GITHUB_ENV"
 
       - name: Build Docker image
         run: |
-          docker buildx build .devcontainer/ubuntu-24.04/ --tag "${{ env.image_tag }}" --label "runnumber=${{ github.run_id }}" --load
+          docker buildx build .devcontainer/ubuntu-24.04/ \
+            --tag "${{ env.image_tag }}" \
+            --label "runnumber=${{ github.run_id }}" \
+            --load
 
       - uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185 # v3
         env:

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -46,7 +46,9 @@ jobs:
         shell: bash
         run: |
           RAW_TAG="${GITHUB_HEAD_REF:-$GITHUB_RUN_ID}"
-          SAFE_TAG=$(echo "$RAW_TAG" | tr '/' '-' | tr '[:upper:]' '[:lower:]')
+          SAFE_TAG=$(echo "$RAW_TAG" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9_.-]/-/g')
+          if ! [[ "$SAFE_TAG" =~ ^[a-z0-9_] ]]; then SAFE_TAG="x-$SAFE_TAG"; fi
+          SAFE_TAG="${SAFE_TAG:0:128}"
           echo "image_tag=devcontainer:${SAFE_TAG}" >> "$GITHUB_ENV"
 
       - name: Build Docker image

--- a/package.json
+++ b/package.json
@@ -434,19 +434,19 @@
       {
         "category": "CMSIS",
         "command": "cmsis-csolution.refresh",
-        "title": "Refresh (reload packs, update RTE)",
+        "title": "Refresh (Reload Packs, Update RTE)",
         "icon": "$(refresh)"
       },
       {
         "category": "CMSIS",
         "command": "cmsis-csolution.reloadPacks",
-        "title": "Refresh (reload packs)",
+        "title": "Refresh (Reload Packs)",
         "icon": "$(refresh)"
       },
       {
         "category": "CMSIS",
         "command": "cmsis-csolution.build",
-        "title": "Build solution",
+        "title": "Build Solution",
         "icon": "$(csolution-build)",
         "enablement": "cmsis-csolution.activeSolutionState == active && cmsis-csolution.buildState == idle"
       },
@@ -460,25 +460,25 @@
       {
         "category": "CMSIS",
         "command": "cmsis-csolution.rebuild",
-        "title": "Rebuild solution",
+        "title": "Rebuild Solution",
         "enablement": "cmsis-csolution.activeSolutionState == active"
       },
       {
         "category": "CMSIS",
         "command": "cmsis-csolution.cmsisLoad",
-        "title": "Load application to target",
+        "title": "Load Application to Target",
         "enablement": "cmsis-csolution.executionState == idle && hasLoadTask"
       },
       {
         "category": "CMSIS",
         "command": "cmsis-csolution.cmsisErase",
-        "title": "Erase device",
+        "title": "Erase Device",
         "enablement": "cmsis-csolution.executionState == idle && hasEraseTask"
       },
       {
         "category": "CMSIS",
         "command": "cmsis-csolution.cmsisRun",
-        "title": "Run current application on target",
+        "title": "Run Current Application on Target",
         "enablement": "cmsis-csolution.executionState == idle && hasRunTask"
       },
       {
@@ -490,27 +490,27 @@
       {
         "category": "CMSIS",
         "command": "cmsis-csolution.clean",
-        "title": "Clean all out and tmp directories",
+        "title": "Clean All 'out' and 'tmp' Directories",
         "enablement": "cmsis-csolution.activeSolutionState == active"
       },
       {
         "category": "CMSIS",
         "command": "cmsis-csolution.cmsisLoadAndRun",
-        "title": "Load & Run application",
+        "title": "Load & Run Application",
         "icon": "$(run)",
         "enablement": "hasLoadRunTask && canStartRun"
       },
       {
         "category": "CMSIS",
         "command": "cmsis-csolution.cmsisStopRun",
-        "title": "Stop running",
+        "title": "Stop Running",
         "icon": "$(debug-stop)",
         "enablement": "canStopRun"
       },
       {
         "category": "CMSIS",
         "command": "cmsis-csolution.cmsisLoadAndDebug",
-        "title": "Load & Debug application",
+        "title": "Load & Debug Application",
         "icon": "$(bug)",
         "enablement": "hasDebugConfig && canStartRun"
       },
@@ -537,7 +537,7 @@
       {
         "category": "CMSIS",
         "command": "cmsis-csolution.activateSolution",
-        "title": "Select as active solution",
+        "title": "Select as Active Solution",
         "icon": "$(folder-opened)"
       },
       {
@@ -548,7 +548,7 @@
       {
         "category": "CMSIS",
         "command": "cmsis-csolution.manageComponentsPacks",
-        "title": "Manage software components",
+        "title": "Manage Software Components",
         "enablement": "cmsis-csolution.activeSolutionState == active",
         "icon": "$(csolution-components)"
       },
@@ -576,14 +576,14 @@
       {
         "category": "CMSIS",
         "command": "cmsis-csolution.unsetClangdContext",
-        "title": "Clangd information active",
+        "title": "Clangd Information Active",
         "enablement": "cmsis-csolution.activeSolutionState == active",
         "icon": "$(info-full-circle)"
       },
       {
         "category": "CMSIS",
         "command": "cmsis-csolution.setClangdContext",
-        "title": "Activate Clangd information",
+        "title": "Activate Clangd Information",
         "enablement": "cmsis-csolution.activeSolutionState == active",
         "icon": "$(info-circle)"
       },
@@ -608,13 +608,13 @@
       {
         "category": "CMSIS",
         "command": "cmsis-csolution.openProjectFile",
-        "title": "Open cproject.yml file",
+        "title": "Open cproject.yml File",
         "icon": "$(go-to-file)"
       },
       {
         "category": "CMSIS",
         "command": "cmsis-csolution.openPrjConfFile",
-        "title": "Open prj.conf file",
+        "title": "Open prj.conf File",
         "icon": "$(go-to-file)"
       },
       {
@@ -626,13 +626,13 @@
       {
         "category": "CMSIS",
         "command": "cmsis-csolution.openLayerFile",
-        "title": "Open clayer.yml file",
+        "title": "Open clayer.yml File",
         "icon": "$(go-to-file)"
       },
       {
         "category": "CMSIS",
         "command": "cmsis-csolution.openLinkerMapFile",
-        "title": "Open linker map file",
+        "title": "Open Linker Map File",
         "icon": "$(go-to-file)"
       },
       {
@@ -644,31 +644,31 @@
       {
         "category": "CMSIS",
         "command": "cmsis-csolution.copyHeaderFile",
-        "title": "Copy header file",
+        "title": "Copy Header File",
         "icon": "$(copy)"
       },
       {
         "category": "CMSIS",
         "command": "cmsis-csolution.mergeFile",
-        "title": "Merge updated config file",
+        "title": "Merge Updated Config File",
         "icon": "$(git-merge)"
       },
       {
         "category": "CMSIS",
         "command": "cmsis-csolution.openSolutionFile",
-        "title": "Open csolution.yml file",
+        "title": "Open csolution.yml File",
         "enablement": "cmsis-csolution.activeSolutionState == active",
         "icon": "$(go-to-file)"
       },
       {
         "category": "CMSIS",
         "command": "cmsis-csolution.getSolutionFile",
-        "title": "Path and name to csolution.yml file of Active Solution"
+        "title": "Path and Name to csolution.yml File of Active Solution"
       },
       {
         "category": "CMSIS",
         "command": "cmsis-csolution.getSolutionPath",
-        "title": "Deprecated: identical with getSolutionFile"
+        "title": "Deprecated: Identical with getSolutionFile"
       },
       {
         "category": "CMSIS",
@@ -678,32 +678,32 @@
       {
         "category": "CMSIS",
         "command": "cmsis-csolution.convertMicroVisionToCsolution",
-        "title": "Convert a μVision project to CMSIS solution…"
+        "title": "Convert a μVision Project to CMSIS Solution…"
       },
       {
         "category": "CMSIS",
         "command": "cmsis-csolution.getBinaryFile",
-        "title": "Path and name of first ELF/DWARF file in Active Target"
+        "title": "Path and Name of First ELF/DWARF File in Active Target"
       },
       {
         "category": "CMSIS",
         "command": "cmsis-csolution.getBinaryFiles",
-        "title": "Path and name of ELF/DWARF files (comma separated) in Active Target"
+        "title": "Path and Name of ELF/DWARF Files (Comma Separated) in Active Target"
       },
       {
         "category": "CMSIS",
         "command": "cmsis-csolution.getProcessorName",
-        "title": "Processor name (pname) of active project; for multi-processor configurations start-pname"
+        "title": "Processor Name (pname) of Active Project; for Multi-Processor Configurations start-pname"
       },
       {
         "category": "CMSIS",
         "command": "cmsis-csolution.getDeviceName",
-        "title": "Device name of Active Target as specified in csolution.yml"
+        "title": "Device Name of Active Target as Specified in csolution.yml"
       },
       {
         "category": "CMSIS",
         "command": "cmsis-csolution.getBoardName",
-        "title": "Board name of Active Target as specified in csolution.yml"
+        "title": "Board Name of Active Target as Specified in csolution.yml"
       },
       {
         "category": "CMSIS",
@@ -713,12 +713,12 @@
       {
         "category": "CMSIS",
         "command": "cmsis-csolution.getTargetPack",
-        "title": "Deprecated: Use getDfpName instead"
+        "title": "Deprecated: Use getDfpName Instead"
       },
       {
         "category": "CMSIS",
         "command": "cmsis-csolution.addToGroup",
-        "title": "Add Groups or Files (only for groups)",
+        "title": "Add Groups or Files (Only for Groups)",
         "icon": "$(plus)"
       },
       {
@@ -750,33 +750,33 @@
       {
         "category": "CMSIS",
         "command": "cmsis-csolution.getDfpName",
-        "title": "Device Family Pack (DFP) used in Active Target"
+        "title": "Device Family Pack (DFP) Used in Active Target"
       },
       {
         "category": "CMSIS",
         "command": "cmsis-csolution.getBspName",
-        "title": "Board Support Pack (BSP) used in Active Target"
+        "title": "Board Support Pack (BSP) Used in Active Target"
       },
       {
         "category": "CMSIS",
         "command": "cmsis-csolution.getDfpPath",
-        "title": "Path to content of DFP used in Active Target"
+        "title": "Path to Content of DFP Used in Active Target"
       },
       {
         "category": "CMSIS",
         "command": "cmsis-csolution.getBspPath",
-        "title": "Path to content of BSP used in Active Target"
+        "title": "Path to Content of BSP Used in Active Target"
       },
       {
         "category": "CMSIS",
         "command": "cmsis-csolution.getPackRootPath",
-        "title": "Path to CMSIS Pack Root Directory, i.e., CMSIS_PACK_ROOT environment variable or OS default",
+        "title": "Path to CMSIS Pack Root Directory, i.e., CMSIS_PACK_ROOT Environment Variable or OS Default",
         "shortTitle": "Path to CMSIS Pack Root"
       },
       {
         "category": "CMSIS",
         "command": "cmsis-csolution.getCbuildRunFile",
-        "title": "Path to cbuild-run.yml file of Active Target"
+        "title": "Path to cbuild-run.yml File of Active Target"
       },
       {
         "command": "cmsis-csolution.list.find",
@@ -792,7 +792,7 @@
       },
       {
         "command": "cmsis-csolution.getActiveTargetSet",
-        "title": "Get name of active run and debug configuration (format: target-type@set)"
+        "title": "Get Name of Active Run and Debug Configuration (Format: target-type@set)"
       }
     ],
     "menus": {

--- a/src/solutions/solution-manager.factories.ts
+++ b/src/solutions/solution-manager.factories.ts
@@ -28,12 +28,14 @@ export const idleSolutionLoadStateFactory = makeFactory<SolutionLoadState>({
     solutionPath: () => undefined,
     loaded: () => undefined,
     converted: () => undefined,
+    activated: () => undefined,
 });
 
 export const activeSolutionLoadStateFactory = makeFactory<SolutionLoadState>({
     solutionPath: () => path.join(faker.system.filePath(), `${faker.word.noun()}.csolution.yml`),
     loaded: () => undefined,
     converted: () => undefined,
+    activated: () => true,
 });
 
 const fireOnDidChangeLoadState = (emitter: vscode.EventEmitter<SolutionLoadStateChangeEvent>) => {

--- a/src/views/solution-outline/commands/open-command.test.ts
+++ b/src/views/solution-outline/commands/open-command.test.ts
@@ -145,7 +145,7 @@ describe('OpenCommand', () => {
         fileItem.setAttribute('docPath', testFile);
         fileItem.addFeature('docFile');
 
-        jest.spyOn(mockOpenFileExternal, 'openFile').mockReturnValue(await Promise.resolve());
+        jest.spyOn(mockOpenFileExternal, 'openFile').mockReturnValue(testFile);
         await commandsProvider.mockRunRegistered(OpenCommand.openDocCommandId, fileItem);
 
         expect(mockOpenFileExternal.openFile).toHaveBeenCalledWith(testFile);
@@ -157,7 +157,7 @@ describe('OpenCommand', () => {
 
         await commandsProvider.mockRunRegistered(OpenCommand.openHelpCommandId);
 
-        jest.spyOn(mockOpenFileExternal, 'openFile').mockReturnValue(await Promise.resolve());
+        jest.spyOn(mockOpenFileExternal, 'openFile').mockReturnValue(OpenCommand.HELP_URL);
 
         await commandsProvider.mockRunRegistered(OpenCommand.openHelpCommandId);
 
@@ -183,7 +183,7 @@ describe('OpenCommand', () => {
 
         await commandsProvider.mockRunRegistered(OpenCommand.openHelpCommandId);
 
-        jest.spyOn(mockOpenFileExternal, 'openFile').mockReturnValue(await Promise.resolve());
+        jest.spyOn(mockOpenFileExternal, 'openFile').mockReturnValue(OpenCommand.HELP_URL);
 
         await commandsProvider.mockRunRegistered(OpenCommand.openHelpCommandId);
 


### PR DESCRIPTION
## Changes
- derive `image_tag `at runtime in a dedicated step
- replace `/` with `-` and lowercase branch names to make tags Docker-valid
- keep GITHUB_RUN_ID as fallback for non-PR runs
- fix build failures on branch names like dependabot/... due to invalid tag format

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [x] 🤖 This change is covered by unit tests (if applicable).
- [x] 🤹 Manual testing has been performed (if necessary).
- [x] 🛡️ Security impacts have been considered (if relevant).
- [x] 📖 Documentation updates are complete (if required).
- [x] 🧠 Third-party dependencies and TPIP updated (if required).
