### PR TITLE
Clean-up solution convert messages in output channel

### DIFF
--- a/src/solutions/cmsis-toolbox.test.ts
+++ b/src/solutions/cmsis-toolbox.test.ts
@@ -127,7 +127,7 @@ describe('CmsisToolbox', () => {
 
         await toolbox.runCmsisTool('cpackget', ['arg1', 'arg2'], outputSpy);
 
-        expect(outputSpy).toHaveBeenCalledWith('🔄 Execute: cpackget arg1 arg2\r\n');
+        expect(outputSpy).toHaveBeenCalledWith('cpackget arg1 arg2\r\n');
     });
 
     it('does not emit execute line when emitExecuteLine is false', async () => {
@@ -135,7 +135,7 @@ describe('CmsisToolbox', () => {
 
         await toolbox.runCmsisTool('cbuild', ['arg1', 'arg2'], outputSpy, undefined, undefined, undefined, false);
 
-        expect(outputSpy).not.toHaveBeenCalledWith('🔄 Execute: cbuild arg1 arg2\r\n');
+        expect(outputSpy).not.toHaveBeenCalledWith('cbuild arg1 arg2\r\n');
     });
 
     it('collect setup messages', () => {

--- a/src/solutions/cmsis-toolbox.ts
+++ b/src/solutions/cmsis-toolbox.ts
@@ -69,13 +69,11 @@ export interface CmsisToolboxManager {
     /** Run csolution RPC method
     * @param method name of RPC method to be executed
     * @param args list of arguments to be passed into the method request
-    * @param onOutput output messages reflecting method's result success or failure
     * @return method result according to each RPC method signature
     */
     runCsolutionRpc(
         method: RpcMethod,
         args: unknown,
-        onOutput: (line: string) => void,
     ): Promise<unknown>
 
     /** Collect Setup Messages
@@ -178,7 +176,7 @@ export class CmsisToolboxManagerImpl implements CmsisToolboxManager {
         }
         // execute call
         if (emitExecuteLine) {
-            msg = `🔄 Execute: ${tool} ${args.join(' ')}\r\n`;
+            msg = `${tool} ${args.join(' ')}\r\n`;
             console.log(msg);
             onOutput(msg);
         }
@@ -195,7 +193,6 @@ export class CmsisToolboxManagerImpl implements CmsisToolboxManager {
         // Print messages
         msg = `${returnCode === 0 ? '✅' : '🟥'} Completed: ${tool} ${cmdMsg}\r\n`;
         console.log(msg);
-        onOutput(msg);
         // release mutex
         release();
         this.runCmsisToolEmitter.fire([false]);
@@ -241,7 +238,6 @@ export class CmsisToolboxManagerImpl implements CmsisToolboxManager {
     public async runCsolutionRpc(
         method: RpcMethod,
         args: unknown,
-        onOutput: (line: string) => void,
     ): Promise<unknown> {
         let msg: string;
         const argsArray = Object.entries(args as never).map(([k, v]) => `${k}: ${v}`);
@@ -265,7 +261,6 @@ export class CmsisToolboxManagerImpl implements CmsisToolboxManager {
         msg = `${(result as rpc.SuccessResult).success ? '☑️' : '🟥'} RPC: ${method}` +
             `${argsArray.length > 0 ? ` { ${argsArray.join(', ')} }` : ''}`;
         console.log(msg);
-        onOutput(msg);
         if (method === 'Shutdown' && (result as rpc.SuccessResult).success) {
             // wait for csolution process to exit
             await this.csolutionService.waitForExit();

--- a/src/solutions/intellisense/compile-commands-generator.ts
+++ b/src/solutions/intellisense/compile-commands-generator.ts
@@ -41,8 +41,7 @@ export class CompileCommandsGeneratorImpl implements CompileCommandsGenerator {
         const task = this.buildTaskProvider.createTask(definition);
         const revealKind = definition.west ? vscode.TaskRevealKind?.Always : vscode.TaskRevealKind?.Silent;
         task.presentationOptions = {
-            ...(revealKind !== undefined ? { reveal: revealKind } : {}),
-            showReuseMessage: false,
+            ...(revealKind !== undefined ? { reveal: revealKind } : {})
         };
         const execution = await vscode.tasks.executeTask(task);
 

--- a/src/solutions/solution-converter.test.ts
+++ b/src/solutions/solution-converter.test.ts
@@ -211,14 +211,12 @@ describe('SolutionConverter', () => {
 
         expect(outputChannel!.mockAppendedStrings).toEqual([
             expect.stringContaining('⚙️ Converting solution...'),
-            expect.stringContaining('☑️ RPC: ListMissingPacks'),
-            expect.stringContaining('☑️ RPC: ConvertSolution'),
-            expect.stringContaining('☑️ cbuild setup database'),
-            expect.stringContaining('☑️ RPC: GetLogMessages'),
+            expect.stringContaining('Check for missing packs...'),
+            expect.stringContaining('Convert solution...'),
+            expect.stringContaining('Setup database...'),
+            expect.stringContaining('Get log messages...'),
             expect.stringContaining('✅ Convert solution completed'),
-            expect.stringContaining(''),
         ]);
-
         expect(completedListener).toHaveBeenCalledTimes(1);
     });
 
@@ -231,11 +229,10 @@ describe('SolutionConverter', () => {
 
         expect(outputChannel!.mockAppendedStrings).toEqual([
             expect.stringContaining('⚙️ Converting solution...'),
-            expect.stringContaining('🟥 RPC: ListMissingPacks'),
-            expect.stringContaining('🟥 RPC: ConvertSolution'),
-            expect.stringContaining('☑️ RPC: GetLogMessages'),
+            expect.stringContaining('Check for missing packs...'),
+            expect.stringContaining('Convert solution...'),
+            expect.stringContaining('Get log messages...'),
             expect.stringContaining('🟥 Convert solution failed'),
-            expect.stringContaining(''),
         ]);
 
         expect(completedListener).toHaveBeenCalledTimes(1);

--- a/src/solutions/solution-converter.ts
+++ b/src/solutions/solution-converter.ts
@@ -112,12 +112,11 @@ export class SolutionConverterImpl implements SolutionConverter {
 
         // restart rpc server to pick up new environment variables
         if (this.data?.restartRpc) {
-            outputChannel.appendLine('🔄 Environment changed: restarting RPC server...');
-            await this.cmsisToolboxManager.runCsolutionRpc('Shutdown', {},
-                line => outputChannel.appendLine(line));
-            await this.cmsisToolboxManager.runCsolutionRpc('LoadPacks', {},
-                line => outputChannel.appendLine(line));
-            outputChannel.appendLine('');
+            outputChannel.append('🔄 Environment changed: restarting RPC server... ');
+            await this.cmsisToolboxManager.runCsolutionRpc('Shutdown', {});
+            outputChannel.append('Loading packs... ');
+            await this.cmsisToolboxManager.runCsolutionRpc('LoadPacks', {});
+            outputChannel.append('\n\n');
         }
 
         if (signal.aborted) {
@@ -127,13 +126,13 @@ export class SolutionConverterImpl implements SolutionConverter {
         outputChannel.appendLine('⚙️ Converting solution...');
         if (this.isDownloadPacksEnabled()) {
             // rpc method: ListMissingPacks
+            outputChannel.append('Check for missing packs... ');
             const result = await this.cmsisToolboxManager.runCsolutionRpc(
                 'ListMissingPacks',
                 {
                     solution: activeSolution,
                     activeTarget: activeTarget,
-                },
-                line => outputChannel.appendLine(line)
+                }
             ) as rpc.ListMissingPacksResult;
             if (result.success && result.packs && result.packs.length > 0) {
                 // download missing packs if any
@@ -145,14 +144,14 @@ export class SolutionConverterImpl implements SolutionConverter {
         }
 
         // rpc method: ConvertSolution
+        outputChannel.append('Convert solution... ');
         const result = await this.cmsisToolboxManager.runCsolutionRpc(
             'ConvertSolution',
             {
                 solution: activeSolution,
                 activeTarget: activeTarget,
                 updateRte: this.data.updateRte ?? false,
-            },
-            line => outputChannel.appendLine(line)
+            }
         ) as rpc.ConvertSolutionResult;
 
         if (signal.aborted) {
@@ -168,13 +167,13 @@ export class SolutionConverterImpl implements SolutionConverter {
         if (!detection) {
             if (result.success) {
                 // check if compile commands need to be updated: call cbuild setup skipping csolution convert step
+                outputChannel.append('Setup database... ');
                 [result.success, cbuildOutput] = await this.compileCommandsGenerator.runCbuildSetup();
-                outputChannel.appendLine(`${result.success ?  '☑️' : '🟥'} cbuild setup database`);
             }
             // rpc method: GetLogMessages
+            outputChannel.append('Get log messages... ');
             logResult = await this.cmsisToolboxManager.runCsolutionRpc(
-                'GetLogMessages', {},
-                line => outputChannel.appendLine(line)
+                'GetLogMessages', {}
             ) as rpc.LogMessages;
             if (logResult?.errors || logResult?.warnings) {
                 this.printErrorsWarnings(logResult);
@@ -191,15 +190,15 @@ export class SolutionConverterImpl implements SolutionConverter {
         csolution?.setLogMessages(logResult);
 
         // print result to output channel
-        outputChannel.appendLine(detection ?
-            '⏳ Action needed: see Configure Solution dialog' :
-            severity == 'error' ?
-                '🟥 Convert solution failed' :
-                severity == 'warning' ?
-                    '🟨 Convert solution completed with warnings' :
-                    '✅ Convert solution completed'
-        );
-        outputChannel.appendLine('');
+        outputChannel.append('\n' + (
+            detection ?
+                '⏳ Action needed: see Configure Solution dialog' :
+                severity == 'error' ?
+                    '🟥 Convert solution failed' :
+                    severity == 'warning' ?
+                        '🟨 Convert solution completed with warnings' :
+                        '✅ Convert solution completed'
+        ) + '\n\n');
         // notify conversion result and detection status asynchronously!
         this.eventHub.fireConvertCompleted({ severity: severity, detection: detection });
     }
@@ -207,16 +206,17 @@ export class SolutionConverterImpl implements SolutionConverter {
     private async printErrorsWarnings(messages?: rpc.LogMessages): Promise<void> {
         const outputChannel = this.outputChannelProvider.getOrCreate(manifest.CMSIS_SOLUTION_OUTPUT_CHANNEL);
         for (const message of messages?.errors ?? []) {
-            outputChannel.appendLine(`csolution error: ${message}`);
+            outputChannel.append(`\ncsolution error: ${message}`);
         }
         for (const message of messages?.warnings ?? []) {
-            outputChannel.appendLine(`csolution warning: ${message}`);
+            outputChannel.append(`\ncsolution warning: ${message}`);
         }
     }
 
     private async downloadMissingPacks(packs: string[]): Promise<void> {
         // call cpackget to download missing packs
         const outputChannel = this.outputChannelProvider.getOrCreate(manifest.CMSIS_SOLUTION_OUTPUT_CHANNEL);
+        outputChannel.append('Downloading missing packs...\n');
         for (const pack of packs) {
             const args = ['add', pack, '--force-reinstall', '--agree-embedded-license', '--no-dependencies'];
             await this.cmsisToolboxManager.runCmsisTool('cpackget', args, line => outputChannel.appendLine(line.trimEnd()), undefined, undefined, true);
@@ -227,13 +227,13 @@ export class SolutionConverterImpl implements SolutionConverter {
         const outputChannel = this.outputChannelProvider.getOrCreate(manifest.CMSIS_SOLUTION_OUTPUT_CHANNEL);
         this.solutionManager.getCsolution()?.setVariablesConfigurations(undefined);
         // rpc method: DiscoverLayers
+        outputChannel.append('Discover Layers... ');
         const result = await this.cmsisToolboxManager.runCsolutionRpc(
             'DiscoverLayers',
             {
                 solution: this.data?.solutionPath ?? '',
                 activeTarget: this.data?.targetSet ?? '',
-            },
-            line => outputChannel.appendLine(line)
+            }
         ) as rpc.DiscoverLayersInfo;
         this.solutionManager.getCsolution()?.setVariablesConfigurations(result.configurations);
         return result.success;

--- a/src/tasks/build/build-runner.test.ts
+++ b/src/tasks/build/build-runner.test.ts
@@ -175,7 +175,7 @@ describe('BuildRunner', () => {
 
             await desktopBuildRunner.run(buildTaskDefinition, onOutput, cancellationTokenFactory().token);
 
-            expect(onOutput.mock.calls[0][0]).toContain('Completed: cbuild');
+            expect(onOutput).toHaveBeenCalledTimes(0);
         });
 
         it('sets the process env, including CMSIS env vars', async () => {

--- a/src/tasks/generator/generator-command.test.ts
+++ b/src/tasks/generator/generator-command.test.ts
@@ -70,7 +70,7 @@ describe('GeneratorCommand', () => {
         await generatorCommand.handleRunGenerator('my-gen', 'debug');
 
         expect(vscode.window.showInformationMessage).toHaveBeenCalledWith(
-            'Starting generator my-gen for context debug ...'
+            'Starting generator my-gen for context debug...'
         );
 
         expect(cmsisToolboxManager.runCmsisTool).toHaveBeenCalledWith(

--- a/src/tasks/generator/generator-command.ts
+++ b/src/tasks/generator/generator-command.ts
@@ -52,10 +52,12 @@ export class GeneratorCommand {
             return;
         }
 
-        vscode.window.showInformationMessage(`Starting generator ${generator} for context ${context} ...`);
+        const msg = `Starting generator ${generator} for context ${context}...`;
+        vscode.window.showInformationMessage(msg);
 
         const executableArgs = ['run', solutionFilePath, '-g', generator, '-c', context];
         const outputChannel = this.outputChannelProvider.getOrCreate(CMSIS_SOLUTION_OUTPUT_CHANNEL);
+        outputChannel.appendLine(msg);
 
         const [result] = await this.cmsisToolboxManager.runCmsisTool('csolution', executableArgs, line => outputChannel.appendLine(line.trimEnd()), undefined,
             undefined, true);


### PR DESCRIPTION
## Fixes
<!-- List the GitHub issue this PR resolves -->
- https://github.com/Open-CMSIS-Pack/vscode-cmsis-solution/issues/63

## Changes
<!-- List the changes this PR introduces -->
- For each RPC request print only the result icon and the method's name. Do not print verbose RPC arguments. For debug purposes they are still printed in the debug console.
- Add solution name and target-set into the first message of convert orchestration.
- Concerning the icon 🟥: red color is widely used to indicate failure/errors and the square form is consistently used in the messages (see screenshot). An icon frequently used for this matter is the red cross ❌ which in my opinion is not aesthetically adequate in this case. Open to better suggestions or to fully remove the icons if they are not desired.
- Concerning links: vscode automatically create links for absolute paths: as long as the solution path is not being printed anymore, the link is also prevented. vscode do not automatically resolve relative paths: such error messages are already handled in the `PROBLEMS` view with proper clickable file position (when available) and "Find in Files" link for searching related keywords. 

UPDATE:
Now the intermediate steps of "convert solution orchestration" are printed in the same line with ellipsis (...) before running each step, producing cleaner and more compact messages in the output channel. See examples of different situations in the screenshots below.

## Screenshots
Example of OLD output channel:
<img width="851" height="372" alt="image" src="https://github.com/user-attachments/assets/c29fdf9d-cc6f-41f4-85f1-39d90fb45735" />

Example of NEW output channel:
```
⚙️ Converting solution USB_Device STM32U585AIIx
Check for missing packs... Convert solution... Get log messages... 
csolution error: HID.cproject.yml:47:1 - schema check failed, verify syntax
csolution error: HID.cproject.yml - cproject not parsed, adding context failed
csolution error: unknown selected context(s):
  HID.Debug+STM32U585AIIx
🟥 Convert solution failed

⚙️ Converting solution USB_Device STM32U585AIIx
Check for missing packs... Downloading missing packs...
cpackget add ARM::CMSIS@~7.0.0 --force-reinstall --agree-embedded-license --no-dependencies
I: Updating public index
I: Downloading index.pidx...
I: Updating cached public PDSC files with new version
I: Adding pack "ARM::CMSIS@~7.0.0"
E: No compatible patch version available for pack version >= 7.0.0, highest available major.minor version is 6.3.x
E: target pack version is not available
Convert solution... Get log messages... 
csolution error: required pack: ARM::CMSIS@~7.0.0 not installed
csolution error: processing context 'HID.Debug+STM32U585AIIx' failed
🟥 Convert solution failed

⚙️ Converting solution USB_Device STM32U585AIIx
Check for missing packs... Convert solution... Setup database... Get log messages... 
csolution warning: 'created-for' in file D:/examples/USB_Device1/USB_Device.csolution.yml specifies a minimum version 2.14.0 (current version 2.13.0)
🟨 Convert solution completed with warnings

⚙️ Converting solution USB_Device STM32U585AIIx
Check for missing packs... Convert solution... Discover Layers... 
⏳ Action needed: see Configure Solution dialog

🔄 Environment changed: restarting RPC server... Loading packs... 

⚙️ Converting solution USB_Device STM32U585AIIx
Check for missing packs... Convert solution... Setup database... Get log messages... 
✅ Convert solution completed
```

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [x] 🤖 This change is covered by unit tests (if applicable).
- [x] 🤹 Manual testing has been performed (if necessary).
- [x] 🛡️ Security impacts have been considered (if relevant).
- [x] 📖 Documentation updates are complete (if required).
- [x] 🧠 Third-party dependencies and TPIP updated (if required).
