### PR TITLE
The Extension needs to reference Open-CMSIS-Pack organization for repository and issues no longer arm-software

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,10 +8,10 @@
   "author": "Jens Reinecke <jens.reinecke@arm.com>",
   "license": "SEE LICENSE IN LICENSE",
   "main": "dist/extension.js",
-  "repository": "https://github.com/ARM-software/vscode-cmsis-csolution",
-  "qna": "https://github.com/ARM-software/vscode-cmsis-csolution/issues/new/choose",
+  "repository": "https://github.com/Open-CMSIS-Pack/vscode-cmsis-solution",
+  "qna": "https://github.com/Open-CMSIS-Pack/vscode-cmsis-solution/issues/new/choose",
   "bugs": {
-    "url": "https://github.com/ARM-software/vscode-cmsis-csolution/issues"
+    "url": "https://github.com/Open-CMSIS-Pack/vscode-cmsis-solution/issues"
   },
   "icon": "media/arm.png",
   "galleryBanner": {


### PR DESCRIPTION
Update/correct links for repo and issues

## Fixes
Outdated links for repo and issues


## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [x] 🤖 This change is covered by unit tests (if applicable).
- [x] 🤹 Manual testing has been performed (if necessary).
- [x] 🛡️ Security impacts have been considered (if relevant).
- [x] 📖 Documentation updates are complete (if required).
- [x] 🧠 Third-party dependencies and TPIP updated (if required).
