### PR TITLE
Open Component View from Problems

### DIFF
--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -43,6 +43,7 @@ export const CONFIG_DOWNLOAD_MISSING_PACKS = 'downloadPacks';
 export const OUTPUT_DIRECTORY = 'outputDirectory';
 export const CONFIG_AUTO_DEBUG_LAUNCH = 'autoDebugLaunch';
 export const CONFIG_BUILD_OUTPUT_VERBOSITY = 'buildOutputVerbosity';
+export const MANAGE_COMPONENTS_PACKS_COMMAND_ID = `${PACKAGE_NAME}.manageComponentsPacks`;
 
 export const MIN_TOOLBOX_VERSION = '2.12.0';
 

--- a/src/solutions/solution-problems.test.ts
+++ b/src/solutions/solution-problems.test.ts
@@ -17,6 +17,7 @@
 import { describe, it, expect, beforeEach } from '@jest/globals';
 import * as vscode from 'vscode';
 import { ExtensionContext } from 'vscode';
+import { MANAGE_COMPONENTS_PACKS_COMMAND_ID } from '../manifest';
 import * as fsUtils from '../utils/fs-utils';
 import * as vscodeUtils from '../utils/vscode-utils';
 import { solutionManagerFactory, MockSolutionManager } from './solution-manager.factories';
@@ -172,5 +173,30 @@ describe('SolutionProblems', () => {
         expect(messages.warnings[0]).toContain('settings.json:3:5 - missing ZEPHYR_BASE environment variable; review "cmsis-csolution.environmentVariables"');
         expect(messages.errors[0]).toContain('.vscode');
         expect(messages.errors[0]).toContain('settings.json:3:5 - exec: "west": executable file not found in $PATH; review "cmsis-csolution.environmentVariables"');
+    });
+
+    it('creates manage components command link with context argument', async () => {
+        await solutionProblems.activate({ subscriptions: [] } as unknown as ExtensionContext);
+        const setSpy = jest.spyOn(vscode.languages.createDiagnosticCollection(), 'set');
+
+        await eventHub.fireConvertCompleted({
+            severity: 'error',
+            detection: false,
+            logMessages: {
+                success: false,
+                errors: ["dependency validation for context 'HID.Debug+STM32U585AIIx' failed:"],
+                warnings: [],
+                info: [],
+            },
+        });
+        await waitTimeout();
+
+        const [, diagnostics] = setSpy.mock.calls[0] as unknown as [vscode.Uri, readonly vscode.Diagnostic[] | undefined];
+        const code = diagnostics?.[0].code as { value: string; target: vscode.Uri };
+        const [command, args] = code.target.toString().split('?');
+
+        expect(code.value).toBe('Manage Components');
+        expect(command).toBe(`command:${MANAGE_COMPONENTS_PACKS_COMMAND_ID}`);
+        expect(JSON.parse(decodeURIComponent(args))).toEqual([{ type: 'context', value: 'HID.Debug+STM32U585AIIx' }]);
     });
 });

--- a/src/solutions/solution-problems.ts
+++ b/src/solutions/solution-problems.ts
@@ -17,6 +17,7 @@
 import * as path from 'node:path';
 import * as vscode from 'vscode';
 import { constructor } from '../generic/constructor';
+import { MANAGE_COMPONENTS_PACKS_COMMAND_ID } from '../manifest';
 import { LogMessages } from '../json-rpc/csolution-rpc-client';
 import * as fsUtils from '../utils/fs-utils';
 import { getFileNameFromPath } from '../utils/path-utils';
@@ -108,6 +109,14 @@ export class SolutionProblemsImpl implements SolutionProblems {
 
     private readonly diagnosticCollection: vscode.DiagnosticCollection = vscode.languages.createDiagnosticCollection('csolution');
 
+    private readonly queryActionPatterns: ReadonlyArray<{ pattern: RegExp; action: 'components-packs' | 'find-in-files' }> = [
+        { pattern: /dependency validation for context '([^']+)' failed:/, action: 'components-packs' },
+        { pattern: /\/([^/\s']+\.[^/\s']+)/, action: 'find-in-files' },
+        { pattern: /'([^']+)'/, action: 'find-in-files' },
+        { pattern: /([A-Za-z0-9_.-]+::[A-Za-z0-9_.-]+(@[A-Za-z0-9_.-]+)*)/, action: 'find-in-files' },
+        { pattern: /([A-Za-z0-9_.-]+@[A-Za-z0-9_.-]*)/, action: 'find-in-files' },
+    ];
+
     constructor(
         private readonly solutionManager: SolutionManager,
         private readonly eventHub: SolutionEventHub,
@@ -136,6 +145,23 @@ export class SolutionProblemsImpl implements SolutionProblems {
     */
     private readonly logMessageRegex = /^(?:(?<filename>(?:[A-Za-z]:)?[^\r\n:]*?[^\s\r\n:])\s*(?::\s*(?<line>\d+))?(?::\s*(?<column>\d+))?\s*-\s+)?(?<message>[\s\S]*)$/;
 
+    private async createDiagnosticRange(file: string, filename: string | undefined, line: string | undefined, column: string | undefined): Promise<vscode.Range> {
+        const startLine = line ? Math.max(Number(line) - 1, 0) : 0;
+        const startCharacter = column ? Math.max(Number(column) - 1, 0) : 0;
+        let endCharacter = startCharacter;
+        if (filename && column) {
+            try {
+                const doc = await vscode.workspace.openTextDocument(file);
+                if (doc && startLine < doc.lineCount) {
+                    endCharacter = doc.lineAt(startLine).range.end.character;
+                }
+            } catch {
+                // Keep default endCharacter when document cannot be opened.
+            }
+        }
+        return new vscode.Range(startLine, startCharacter, startLine, endCharacter);
+    }
+
     private async addDiagnosticEntry(message: string, severity: vscode.DiagnosticSeverity, files: Map<string, string>): Promise<boolean> {
         // skip excluded messages
         if (this.isMessageExcluded(message)) {
@@ -143,48 +169,30 @@ export class SolutionProblemsImpl implements SolutionProblems {
         }
         // parse message according to logMessageRegex
         const m = message.match(this.logMessageRegex);
-        if (m?.groups) {
-            const { filename, line, column, message } = m.groups;
-            const normalizedFilename = filename ? getFileNameFromPath(filename) : undefined;
-            const fromMap = (filename && files.get(filename)) || (normalizedFilename && files.get(normalizedFilename));
-            const file = fromMap || (filename && path.isAbsolute(filename) ? filename : undefined) || this.solutionManager.getCsolution()?.solutionPath;
-            if (!file) {
-                return false;
-            }
-            const startLine = line ? Math.max(Number(line) - 1, 0) : 0;
-            const startCharacter = column ? Math.max(Number(column) - 1, 0) : 0;
-            let endCharacter = startCharacter;
-            if (filename && column) {
-                try {
-                    const doc = await vscode.workspace.openTextDocument(file);
-                    if (doc && startLine < doc.lineCount) {
-                        endCharacter = doc.lineAt(startLine).range.end.character;
-                    }
-                } catch {
-                    // Keep default endCharacter when document cannot be opened.
-                }
-            }
-            const range = new vscode.Range(startLine, startCharacter, startLine, endCharacter);
-            const entry = new vscode.Diagnostic(range, message, severity);
-            entry.source = 'csolution';
-
-            if (!line && !column) {
-                // add 'Find in Files' action only if no line/column info is available
-                const args = this.createQueryArgs(message);
-                if (args) {
-                    entry.code = {
-                        value: 'Find in Files',
-                        target: vscode.Uri.parse(`command:workbench.action.findInFiles?${args}`)
-                    };
-                }
-            }
-
-            // append diagnostic entry
-            const uri = vscode.Uri.file(path.posix.normalize(file));
-            this.diagnosticCollection.set(uri, [...(this.diagnosticCollection.get(uri) ?? []), entry]);
-            return true;
+        if (!m || !m.groups) {
+            return false;
         }
-        return false;
+        const { filename, line, column, message: messageText } = m.groups;
+        const normalizedFilename = filename ? getFileNameFromPath(filename) : undefined;
+        const fromMap = (filename && files.get(filename)) || (normalizedFilename && files.get(normalizedFilename));
+        const file = fromMap || (filename && path.isAbsolute(filename) ? filename : undefined) || this.solutionManager.getCsolution()?.solutionPath;
+        if (!file) {
+            return false;
+        }
+        const range = await this.createDiagnosticRange(file, filename, line, column);
+
+        const entry = new vscode.Diagnostic(range, messageText, severity);
+        entry.source = 'csolution';
+
+        if (!line && !column) {
+            // add 'Find in Files' action only if no line/column info is available
+            entry.code = this.createDiagnosticActionCode(messageText);
+        }
+
+        // append diagnostic entry
+        const uri = vscode.Uri.file(path.posix.normalize(file));
+        this.diagnosticCollection.set(uri, [...(this.diagnosticCollection.get(uri) ?? []), entry]);
+        return true;
     }
 
     private async updateDiagnostics(messages: LogMessages): Promise<void> {
@@ -265,30 +273,17 @@ export class SolutionProblemsImpl implements SolutionProblems {
         return this.excludePatterns.some(pattern => pattern.test(message));
     }
 
-    /**
-    *  patterns to extract query from log message for 'Find in Files' action
-    */
-    private readonly queryPatterns = [
-        /(?:MISSING|SELECTABLE)\s+(.*)/,                          // component dependency
-        /\/([^/\s']+\.[^/\s']+)/,                                 // capture filename from path
-        /'([^']+)'/,                                              // single quotes
-        /([A-Za-z0-9_.-]+::[A-Za-z0-9_.-]+(@[A-Za-z0-9_.-]+)*)/,  // pack/component identifier
-        /([A-Za-z0-9_.-]+@[A-Za-z0-9_.-]*)/,                      // compiler/tool identifier
-    ];
-
-    private createQueryArgs(message: string): string | undefined {
-        // empirically find possible query patterns
-        let query;
-        for (const pattern of this.queryPatterns) {
-            const match = message.match(pattern);
-            if (match) {
-                query = match[1];
-                break;
+    private findQueryActionInMessage(message: string): { query: string; action: 'components-packs' | 'find-in-files' } | undefined {
+        for (const item of this.queryActionPatterns) {
+            const match = message.match(item.pattern);
+            if (match?.[1]) {
+                return { query: match[1], action: item.action };
             }
         }
-        if (!query) {
-            return undefined;
-        }
+        return undefined;
+    }
+
+    private encodeFindInFilesArgs(query: string): string {
         const args = {
             query: query,
             filesToInclude: '*.yml,*.yaml', // limit search to yml files
@@ -301,6 +296,27 @@ export class SolutionProblemsImpl implements SolutionProblems {
         };
         return encodeURIComponent(JSON.stringify(args));
     }
+
+    private createDiagnosticActionCode(message: string): vscode.Diagnostic['code'] | undefined {
+        const queryAction = this.findQueryActionInMessage(message);
+        if (!queryAction) {
+            return undefined;
+        }
+
+        if (queryAction.action === 'components-packs') {
+            return {
+                value: 'Manage Components',
+                target: vscode.Uri.parse(`command:${MANAGE_COMPONENTS_PACKS_COMMAND_ID}`)
+            };
+        }
+
+        const args = this.encodeFindInFilesArgs(queryAction.query);
+        return {
+            value: 'Find in Files',
+            target: vscode.Uri.parse(`command:workbench.action.findInFiles?${args}`)
+        };
+    }
+
 }
 
 export const SolutionProblems = constructor<typeof SolutionProblemsImpl, SolutionProblems>(SolutionProblemsImpl);

--- a/src/solutions/solution-problems.ts
+++ b/src/solutions/solution-problems.ts
@@ -297,6 +297,10 @@ export class SolutionProblemsImpl implements SolutionProblems {
         return encodeURIComponent(JSON.stringify(args));
     }
 
+    private encodeCommandArgs(args: unknown[]): string {
+        return encodeURIComponent(JSON.stringify(args));
+    }
+
     private createDiagnosticActionCode(message: string): vscode.Diagnostic['code'] | undefined {
         const queryAction = this.findQueryActionInMessage(message);
         if (!queryAction) {
@@ -304,9 +308,10 @@ export class SolutionProblemsImpl implements SolutionProblems {
         }
 
         if (queryAction.action === 'components-packs') {
+            const args = this.encodeCommandArgs([{ type: 'context', value: queryAction.query }]);
             return {
                 value: 'Manage Components',
-                target: vscode.Uri.parse(`command:${MANAGE_COMPONENTS_PACKS_COMMAND_ID}`)
+                target: vscode.Uri.parse(`command:${MANAGE_COMPONENTS_PACKS_COMMAND_ID}?${args}`)
             };
         }
 

--- a/src/views/manage-components-packs/components-packs-webview-main.test.ts
+++ b/src/views/manage-components-packs/components-packs-webview-main.test.ts
@@ -204,6 +204,26 @@ describe('ComponentsPacksWebviewMain', () => {
             expect((componentsPacksWebviewMain as any).openWebview).not.toHaveBeenCalled();
             expect(messageProvider.showWarningMessage).toHaveBeenCalledWith('No valid project found in the active solution.');
         });
+
+        it('calls openWebview with project resolved from typed context payload', async () => {
+            const context = 'HID.Debug+STM32U585AIIx';
+            jest.spyOn(componentsPacksWebviewMain as any, 'resolveProjectPathFromContext').mockReturnValue(projectPath);
+
+            await (componentsPacksWebviewMain as any).handleWebviewCommand({ type: 'context', value: context });
+
+            expect((componentsPacksWebviewMain as any).openWebview).toHaveBeenCalledTimes(1);
+            expect((componentsPacksWebviewMain as any).openWebview).toHaveBeenCalledWith(projectPath, undefined);
+        });
+
+        it('shows warning when typed context payload cannot be resolved', async () => {
+            const context = 'HID.Debug+STM32U585AIIx';
+            jest.spyOn(componentsPacksWebviewMain as any, 'resolveProjectPathFromContext').mockReturnValue(undefined);
+
+            await (componentsPacksWebviewMain as any).handleWebviewCommand({ type: 'context', value: context });
+
+            expect((componentsPacksWebviewMain as any).openWebview).not.toHaveBeenCalled();
+            expect(messageProvider.showWarningMessage).toHaveBeenCalledWith(`No valid project found for context: ${context}.`);
+        });
     });
 
     describe('openWebview', () => {

--- a/src/views/manage-components-packs/components-packs-webview-main.ts
+++ b/src/views/manage-components-packs/components-packs-webview-main.ts
@@ -78,6 +78,11 @@ const packsRowsFromInfo = (packsInfo: PacksInfo, solutionPath: string): PackRowD
     return (packsInfo.packs || []).map(pack => packsRowFromInfo(pack, solutionPath));
 };
 
+type ManageComponentsCommandPayload = {
+    type: 'context';
+    value: string;
+};
+
 export class ComponentsPacksWebviewMain {
     private readonly webviewManager: WebviewManager<Messages.IncomingMessage, Messages.OutgoingMessage>;
 
@@ -134,9 +139,25 @@ export class ComponentsPacksWebviewMain {
         this.manageComponentsActions.setCurrentProject(this.currentProject);
     }
 
-    private async handleWebviewCommand(treeNode: COutlineItem | undefined) {
-        if (treeNode) {
-            await this.openWebview(treeNode.cprojectPath, treeNode.clayerPath);
+    private resolveProjectPathFromContext(context: string): string | undefined {
+        const descriptors = this.solutionManager.getCsolution()?.getContextDescriptors();
+        return descriptors?.find(descriptor => descriptor.displayName === context)?.projectPath;
+    }
+
+    private async handleWebviewCommand(commandArg: COutlineItem | ManageComponentsCommandPayload | undefined) {
+        if (commandArg instanceof COutlineItem) {
+            await this.openWebview(commandArg.cprojectPath, commandArg.clayerPath);
+            return;
+        }
+
+        if (commandArg?.type === 'context') {
+            const projectId = this.resolveProjectPathFromContext(commandArg.value);
+            if (!projectId) {
+                this.messageProvider.showWarningMessage(`No valid project found for context: ${commandArg.value}.`);
+                return;
+            }
+
+            await this.openWebview(projectId, undefined);
             return;
         }
 

--- a/src/views/manage-components-packs/components-packs-webview-main.ts
+++ b/src/views/manage-components-packs/components-packs-webview-main.ts
@@ -81,8 +81,6 @@ const packsRowsFromInfo = (packsInfo: PacksInfo, solutionPath: string): PackRowD
 export class ComponentsPacksWebviewMain {
     private readonly webviewManager: WebviewManager<Messages.IncomingMessage, Messages.OutgoingMessage>;
 
-    public static readonly WEBVIEW_COMMAND_ID = `${manifest.PACKAGE_NAME}.manageComponentsPacks`;
-
     private currentProject: CurrentProject;
 
     private componentTree!: CtRoot;
@@ -123,7 +121,7 @@ export class ComponentsPacksWebviewMain {
             this.webviewManager.onDidReceiveMessage(this.handleMessage, this),
             this.webviewManager.onDidDispose(this.dispose, this),
             this.solutionManager.onDidChangeLoadState(this.handleSolutionLoadChange, this),
-            this.commandsProvider.registerCommand(ComponentsPacksWebviewMain.WEBVIEW_COMMAND_ID, this.handleWebviewCommand, this),
+            this.commandsProvider.registerCommand(manifest.MANAGE_COMPONENTS_PACKS_COMMAND_ID, this.handleWebviewCommand, this),
         );
 
         await this.webviewManager.activate(context);


### PR DESCRIPTION
## Fixes
<!-- List the GitHub issue this PR resolves -->
- #172 

## Changes
<!-- List the changes this PR introduces -->
- Find in files is replaced by opening Component view for dependency problems
- corresponding command is adjusted  to accept context string

## Screenshots
<!-- Show UI changes with screenshots to ease UX/UI feedback: -->
<img width="2299" height="1166" alt="image" src="https://github.com/user-attachments/assets/16d21225-2b92-459e-9c51-c00527d420f1" />

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [ ] 🤖 This change is covered by unit tests (if applicable).
- [ ] 🤹 Manual testing has been performed (if necessary).
- [ ] 🛡️ Security impacts have been considered (if relevant).
- [ ] 📖 Documentation updates are complete (if required).
- [ ] 🧠 Third-party dependencies and TPIP updated (if required).
