### PR TITLE
Extend copyright script to check .tsx and .css files

### DIFF
--- a/media/styles.css
+++ b/media/styles.css
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Arm Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 body section {
     display: flex;
 }

--- a/scripts/copyright-manager.ts
+++ b/scripts/copyright-manager.ts
@@ -24,7 +24,7 @@ const args = minimist(process.argv.slice(2));
 const mode = args.mode || 'check';
 
 
-const DEFAULT_INCLUDE_GLOBS = ['src/**/*.ts', 'scripts/**/*.ts', 'api/**/*.ts', '__mocks__/**/*.ts'];
+const DEFAULT_INCLUDE_GLOBS = ['src/**/*.ts', 'scripts/**/*.ts', 'api/**/*.ts', '__mocks__/**/*.ts', '**/*.tsx', '**/*.css'];
 const DEFAULT_EXCLUDE_GLOBS = ['**/node_modules/**', 'coverage/**', 'dist/**', 'tools/**', 'src/json-rpc/**', 'test-data/**', 'test-workspace/**'];
 
 const includeGlobs: string[] = args.include ? args.include.split(',') : DEFAULT_INCLUDE_GLOBS;
@@ -47,7 +47,7 @@ const COPYRIGHT_TEXT = `/**
  */`;
 
 // Regular expression to match the copyright notice
-const COPYRIGHT_REGEX = /\/\*\*\n \* Copyright 20\d{2}(?:-(?:20\d{2}))? Arm Limited[\s\S]*?\*\//;
+const COPYRIGHT_REGEX = /\/\*\*\r?\n \* Copyright 20\d{2}(?:-(?:20\d{2}))? Arm Limited[\s\S]*?\*\//;
 
 function getFiles(): string[] {
     const allFiles: string[] = [];

--- a/src/views/common/components/cmsis-codicon.tsx
+++ b/src/views/common/components/cmsis-codicon.tsx
@@ -1,5 +1,17 @@
-/*
- * Copyright (C) 2026 Arm Limited
+/**
+ * Copyright 2026 Arm Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 import React from 'react';

--- a/src/views/common/components/compact-dropdown.css
+++ b/src/views/common/components/compact-dropdown.css
@@ -1,5 +1,17 @@
-/*
- * Copyright (c) 2022-2026 Arm Limited
+/**
+ * Copyright 2022-2026 Arm Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 :root {

--- a/src/views/common/components/compact-dropdown.test.tsx
+++ b/src/views/common/components/compact-dropdown.test.tsx
@@ -1,8 +1,18 @@
 /**
- * Copyright (C) 2021-2026 Arm Limited
+ * Copyright 2026 Arm Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
-
 
 import 'jest';
 import * as React from 'react';

--- a/src/views/common/components/compact-dropdown.tsx
+++ b/src/views/common/components/compact-dropdown.tsx
@@ -1,5 +1,17 @@
 /**
- * Copyright (C) 2021-2026 Arm Limited
+ * Copyright 2026 Arm Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 import * as React from 'react';

--- a/src/views/common/components/dropdown-select.css
+++ b/src/views/common/components/dropdown-select.css
@@ -1,5 +1,17 @@
-/*
- * Copyright (c) 2022-2026 Arm Limited
+/**
+ * Copyright 2022-2026 Arm Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 .dropdown-select-label {

--- a/src/views/common/components/dropdown-select.test-utils.test.tsx
+++ b/src/views/common/components/dropdown-select.test-utils.test.tsx
@@ -1,5 +1,17 @@
 /**
- * Copyright (C) 2024-2026 Arm Limited
+ * Copyright 2024-2026 Arm Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 import { simulateClickEvent } from '../../../__test__/dom-events';

--- a/src/views/common/components/dropdown-select.test.tsx
+++ b/src/views/common/components/dropdown-select.test.tsx
@@ -1,8 +1,18 @@
 /**
- * Copyright (C) 2022-2026 Arm Limited
+ * Copyright 2022-2026 Arm Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
-
 
 import { createRoot, Root } from 'react-dom/client';
 import * as React from 'react';

--- a/src/views/common/components/dropdown-select.tsx
+++ b/src/views/common/components/dropdown-select.tsx
@@ -1,6 +1,19 @@
 /**
- * Copyright (C) 2019-2026 Arm Limited
+ * Copyright 2019-2026 Arm Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 import './dropdown-select.css';
 import * as React from 'react';
 import { ReactNode } from 'react';

--- a/src/views/common/components/dropdown.css
+++ b/src/views/common/components/dropdown.css
@@ -1,5 +1,17 @@
 /**
- * Copyright (C) 2022-2026 Arm Limited
+ * Copyright 2022-2026 Arm Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 .mbs-dropdown-anchor {

--- a/src/views/common/components/dropdown.test.tsx
+++ b/src/views/common/components/dropdown.test.tsx
@@ -1,8 +1,18 @@
 /**
- * Copyright (C) 2021-2026 Arm Limited
+ * Copyright 2021-2026 Arm Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
-
 
 import { createRoot, Root } from 'react-dom/client';
 import * as React from 'react';

--- a/src/views/common/components/dropdown.tsx
+++ b/src/views/common/components/dropdown.tsx
@@ -1,6 +1,19 @@
 /**
- * Copyright (C) 2019-2026 Arm Limited
+ * Copyright 2019-2026 Arm Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 import './dropdown.css';
 import * as React from 'react';
 import { KeyboardEvent, ReactNode, RefObject } from 'react';

--- a/src/views/common/components/file-path-picker.css
+++ b/src/views/common/components/file-path-picker.css
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Arm Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 .file-location-picker {
     display: flex;
     margin-bottom: 10px;

--- a/src/views/common/components/file-path-picker.test.tsx
+++ b/src/views/common/components/file-path-picker.test.tsx
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Arm Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 import { FileLocationPicker } from './file-path-picker';

--- a/src/views/common/components/file-path-picker.tsx
+++ b/src/views/common/components/file-path-picker.tsx
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Arm Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import './file-path-picker.css';
 import * as React from 'react';
 import { VSCodeButton } from '@vscode/webview-ui-toolkit/react';

--- a/src/views/common/components/layer-errors.css
+++ b/src/views/common/components/layer-errors.css
@@ -1,6 +1,18 @@
- /*
-  * Copyright (c) 2024-2026 Arm Limited
-  */
+/**
+ * Copyright 2024-2026 Arm Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 .layer-errors {
     width:auto;

--- a/src/views/common/components/layer-errors.tsx
+++ b/src/views/common/components/layer-errors.tsx
@@ -1,5 +1,17 @@
-/*
- * Copyright (c) 2023-2026 Arm Limited
+/**
+ * Copyright 2023-2026 Arm Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 import React, { ReactNode } from 'react';

--- a/src/views/common/components/modal-wrapper.test.tsx
+++ b/src/views/common/components/modal-wrapper.test.tsx
@@ -1,6 +1,19 @@
-/*
- * Copyright (C) 2025-2026 Arm Limited
+/**
+ * Copyright 2025-2026 Arm Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 import { ModalManager } from './modal-wrapper';
 import { act } from 'react-dom/test-utils';
 import { waitFor } from '@testing-library/react';

--- a/src/views/common/components/modal-wrapper.tsx
+++ b/src/views/common/components/modal-wrapper.tsx
@@ -1,5 +1,17 @@
-/*
- * Copyright (C) 2025-2026 Arm Limited
+/**
+ * Copyright 2025-2026 Arm Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 import React from 'react';

--- a/src/views/common/components/radio-button.css
+++ b/src/views/common/components/radio-button.css
@@ -1,6 +1,18 @@
- /*
-  * Copyright (c) 2023-2026 Arm Limited
-  */
+/**
+ * Copyright 2023-2026 Arm Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 .radio-button input[type="radio"] {
     display: none;

--- a/src/views/common/components/radio-button.test.tsx
+++ b/src/views/common/components/radio-button.test.tsx
@@ -1,5 +1,17 @@
-/*
- * Copyright (c) 2023-2026 Arm Limited
+/**
+ * Copyright 2023-2026 Arm Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 import 'jest';

--- a/src/views/common/components/radio-button.tsx
+++ b/src/views/common/components/radio-button.tsx
@@ -1,5 +1,17 @@
-/*
- * Copyright (c) 2023-2026 Arm Limited
+/**
+ * Copyright 2023-2026 Arm Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 import React from 'react';

--- a/src/views/common/components/search-input.css
+++ b/src/views/common/components/search-input.css
@@ -1,5 +1,17 @@
 /**
- * Copyright (C) 2024-2026 Arm Limited
+ * Copyright 2024-2026 Arm Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 .search-input-wrapper {

--- a/src/views/common/components/search-input.tsx
+++ b/src/views/common/components/search-input.tsx
@@ -1,5 +1,17 @@
 /**
- * Copyright (C) 2019-2026 Arm Limited
+ * Copyright 2019-2026 Arm Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 import './search-input.css';

--- a/src/views/common/components/search-list.css
+++ b/src/views/common/components/search-list.css
@@ -1,5 +1,17 @@
 /**
- * Copyright (C) 2022-2026 Arm Limited
+ * Copyright 2022-2026 Arm Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 .search-list-input {

--- a/src/views/common/components/search-list.test.tsx
+++ b/src/views/common/components/search-list.test.tsx
@@ -1,8 +1,18 @@
 /**
- * Copyright (C) 2021-2026 Arm Limited
+ * Copyright 2021-2026 Arm Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
-
 
 import { createRoot } from 'react-dom/client';
 import * as React from 'react';

--- a/src/views/common/components/search-list.tsx
+++ b/src/views/common/components/search-list.tsx
@@ -1,5 +1,17 @@
 /**
- * Copyright (C) 2019-2026 Arm Limited
+ * Copyright 2019-2026 Arm Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 import * as React from 'react';

--- a/src/views/common/components/searchable-tree-view.tsx
+++ b/src/views/common/components/searchable-tree-view.tsx
@@ -1,5 +1,17 @@
 /**
- * Copyright (C) 2022-2026 Arm Limited
+ * Copyright 2022-2026 Arm Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 import * as React from 'react';

--- a/src/views/common/components/simple-list.css
+++ b/src/views/common/components/simple-list.css
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Arm Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 .simple-list-namespace .ant-list .ant-list-item {
     border-block-end: unset;
     padding: 8px;

--- a/src/views/common/components/simple-list.tsx
+++ b/src/views/common/components/simple-list.tsx
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Arm Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import './simple-list.css';
 import React from 'react';
 import { List } from 'antd';

--- a/src/views/common/components/tooltip-question.css
+++ b/src/views/common/components/tooltip-question.css
@@ -1,5 +1,17 @@
-/*
- * Copyright (c) 2024-2026 Arm Limited
+/**
+ * Copyright 2024-2026 Arm Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 .tooltip.codicon-question::before {

--- a/src/views/common/components/tooltip-question.tsx
+++ b/src/views/common/components/tooltip-question.tsx
@@ -1,5 +1,17 @@
-/*
- * Copyright (c) 2024-2026 Arm Limited
+/**
+ * Copyright 2024-2026 Arm Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 import React from 'react';

--- a/src/views/common/components/tree-view.css
+++ b/src/views/common/components/tree-view.css
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Arm Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 div.components-tree-view {
     position: relative;
     list-style: none;

--- a/src/views/common/components/tree-view.tsx
+++ b/src/views/common/components/tree-view.tsx
@@ -1,5 +1,17 @@
 /**
- * Copyright (C) 2022-2026 Arm Limited
+ * Copyright 2022-2026 Arm Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 import * as React from 'react';

--- a/src/views/common/style/antd-overrides.css
+++ b/src/views/common/style/antd-overrides.css
@@ -1,5 +1,17 @@
 /**
- * Copyright (C) 2025-2026 Arm Limited
+ * Copyright 2025-2026 Arm Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 .ant-btn {

--- a/src/views/common/style/base.css
+++ b/src/views/common/style/base.css
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Arm Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 @import "./reset.css";
 @import "./variables.css";
 @import "./elements.css";

--- a/src/views/common/style/elements.css
+++ b/src/views/common/style/elements.css
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Arm Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 h1 {
     margin: 0 0 0.5rem 0;
 }

--- a/src/views/common/style/reset.css
+++ b/src/views/common/style/reset.css
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Arm Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 body, html {
     padding: 0;
     margin: 0;

--- a/src/views/common/style/theme-overrides.css
+++ b/src/views/common/style/theme-overrides.css
@@ -1,4 +1,20 @@
 /**
+ * Copyright 2026 Arm Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
  * Some themes don't work well with (or don't even provide) the colour variables we've chosen
  * to style our elements. For example, the builtin VSCode Light theme does not provide --vscode-input-border.
  *

--- a/src/views/common/style/variables.css
+++ b/src/views/common/style/variables.css
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Arm Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 :root {
     --arm-ui-padding: 6px;
     --arm-input-padding: 4px 8px;

--- a/src/views/config-wizard/app.ts
+++ b/src/views/config-wizard/app.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2026 Arm Limited
+ * Copyright 2023-2026 Arm Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -12,10 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- */
-
-/*
- * Copyright (C) 2023-2026 Arm Limited
  */
 
 import { createRoot } from 'react-dom/client';

--- a/src/views/config-wizard/confwiz-webview-view-component.tsx
+++ b/src/views/config-wizard/confwiz-webview-view-component.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright 2023 - 2026 Arm Limited
+ * Copyright 2023-2026 Arm Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/views/config-wizard/confwiz-webview.css
+++ b/src/views/config-wizard/confwiz-webview.css
@@ -1,5 +1,17 @@
 /**
- * Copyright (C) 2025 - 2026 Arm Limited
+ * Copyright 2025-2026 Arm Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 @import "~@vscode/codicons/dist/codicon.css";

--- a/src/views/create-solutions/view/components/create-solution.css
+++ b/src/views/create-solutions/view/components/create-solution.css
@@ -1,7 +1,19 @@
 @import "../../../common/style/base.css";
 
-/*
- * Copyright (c) 2022-2026 Arm Limited
+/**
+ * Copyright 2022-2026 Arm Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 .create-solution-frame {

--- a/src/views/create-solutions/view/components/create-solution.test.tsx
+++ b/src/views/create-solutions/view/components/create-solution.test.tsx
@@ -1,5 +1,17 @@
 /**
- * Copyright (C) 2022-2026 Arm Limited
+ * Copyright 2022-2026 Arm Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 import 'jest';

--- a/src/views/create-solutions/view/components/create-solution.tsx
+++ b/src/views/create-solutions/view/components/create-solution.tsx
@@ -1,5 +1,17 @@
 /**
- * Copyright (C) 2024-2026 Arm Limited
+ * Copyright 2024-2026 Arm Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 import { VSCodeButton, VSCodeCheckbox } from '@vscode/webview-ui-toolkit/react';

--- a/src/views/create-solutions/view/components/example-dropdown-tree.test.tsx
+++ b/src/views/create-solutions/view/components/example-dropdown-tree.test.tsx
@@ -1,5 +1,17 @@
 /**
- * Copyright (C) 2024-2026 Arm Limited
+ * Copyright 2024-2026 Arm Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 import * as React from 'react';

--- a/src/views/create-solutions/view/components/example-dropdown-tree.tsx
+++ b/src/views/create-solutions/view/components/example-dropdown-tree.tsx
@@ -1,5 +1,17 @@
 /**
- * Copyright (C) 2024-2026 Arm Limited
+ * Copyright 2024-2026 Arm Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 import { Example as ApiExample, RefApp } from '../../../../core-tools/client/packs_pb';

--- a/src/views/create-solutions/view/components/hardware-panel.css
+++ b/src/views/create-solutions/view/components/hardware-panel.css
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Arm Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 .hardware-panel-container {
     flex-direction: column;
     margin-left: 10px;

--- a/src/views/create-solutions/view/components/hardware-panel.test.tsx
+++ b/src/views/create-solutions/view/components/hardware-panel.test.tsx
@@ -1,6 +1,19 @@
 /**
- * Copyright (C) 2023-2026 Arm Limited
+ * Copyright 2023-2026 Arm Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 import * as React from 'react';
 import { createRoot } from 'react-dom/client';
 import { Simulate } from 'react-dom/test-utils';

--- a/src/views/create-solutions/view/components/hardware-panel.tsx
+++ b/src/views/create-solutions/view/components/hardware-panel.tsx
@@ -1,5 +1,17 @@
 /**
- * Copyright (C) 2023-2026 Arm Limited
+ * Copyright 2023-2026 Arm Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 import * as React from 'react';

--- a/src/views/create-solutions/view/components/hardware-row.css
+++ b/src/views/create-solutions/view/components/hardware-row.css
@@ -1,7 +1,19 @@
 @import "../../../common/style/base.css";
 
-/*
- * Copyright (c) 2024-2026 Arm Limited
+/**
+ * Copyright 2024-2026 Arm Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 .searchtree-container {

--- a/src/views/create-solutions/view/components/hardware-row.test.tsx
+++ b/src/views/create-solutions/view/components/hardware-row.test.tsx
@@ -1,5 +1,17 @@
 /**
- * Copyright (C) 2024-2026 Arm Limited
+ * Copyright 2024-2026 Arm Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 import { TextField } from '@vscode/webview-ui-toolkit';

--- a/src/views/create-solutions/view/components/hardware-row.tsx
+++ b/src/views/create-solutions/view/components/hardware-row.tsx
@@ -1,5 +1,17 @@
 /**
- * Copyright (C) 2024-2026 Arm Limited
+ * Copyright 2024-2026 Arm Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 import * as React from 'react';

--- a/src/views/create-solutions/view/components/project-configuration.css
+++ b/src/views/create-solutions/view/components/project-configuration.css
@@ -1,5 +1,17 @@
-/*
- * Copyright (c) 2023-2026 Arm Limited
+/**
+ * Copyright 2023-2026 Arm Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 .project-config-row {

--- a/src/views/create-solutions/view/components/project-configuration.test.tsx
+++ b/src/views/create-solutions/view/components/project-configuration.test.tsx
@@ -1,5 +1,17 @@
-/*
- * Copyright (c) 2023-2026 Arm Limited
+/**
+ * Copyright 2023-2026 Arm Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 import React from 'react';

--- a/src/views/create-solutions/view/components/project-configuration.tsx
+++ b/src/views/create-solutions/view/components/project-configuration.tsx
@@ -1,5 +1,17 @@
-/*
- * Copyright (c) 2023-2026 Arm Limited
+/**
+ * Copyright 2023-2026 Arm Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 import * as React from 'react';

--- a/src/views/create-solutions/view/components/validation-message.tsx
+++ b/src/views/create-solutions/view/components/validation-message.tsx
@@ -1,5 +1,17 @@
-/*
- * Copyright (c) 2023-2026 Arm Limited
+/**
+ * Copyright 2023-2026 Arm Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 import * as React from 'react';

--- a/src/views/manage-components-packs/view/components/arm-empty.tsx
+++ b/src/views/manage-components-packs/view/components/arm-empty.tsx
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Arm Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 
 /**

--- a/src/views/manage-components-packs/view/components/component-pack-manager.css
+++ b/src/views/manage-components-packs/view/components/component-pack-manager.css
@@ -1,5 +1,17 @@
-/*
- * Copyright (c) 2022-2026 Arm Limited
+/**
+ * Copyright 2022-2026 Arm Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 @import '../../../common/style/base.css';

--- a/src/views/manage-components-packs/view/components/component-pack-manager.test.tsx
+++ b/src/views/manage-components-packs/view/components/component-pack-manager.test.tsx
@@ -1,5 +1,17 @@
 /**
- * Copyright (C) 2020-2026 Arm Limited
+ * Copyright 2020-2026 Arm Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 import 'jest';

--- a/src/views/manage-components-packs/view/components/component-pack-manager.tsx
+++ b/src/views/manage-components-packs/view/components/component-pack-manager.tsx
@@ -1,5 +1,17 @@
 /**
- * Copyright (C) 2020-2026 Arm Limited
+ * Copyright 2020-2026 Arm Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 import '../../../common/style/antd-overrides.css';

--- a/src/views/manage-components-packs/view/components/component-pack-target-select.tsx
+++ b/src/views/manage-components-packs/view/components/component-pack-target-select.tsx
@@ -1,5 +1,17 @@
 /**
- * Copyright (C) 2025-2026 Arm Limited
+ * Copyright 2025-2026 Arm Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 import { TreeSelect } from 'antd';

--- a/src/views/manage-components-packs/view/components/component-properties.test.tsx
+++ b/src/views/manage-components-packs/view/components/component-properties.test.tsx
@@ -1,6 +1,18 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /**
- * Copyright (C) 2026 Arm Limited
+ * Copyright 2026 Arm Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 import 'jest';

--- a/src/views/manage-components-packs/view/components/component-properties.tsx
+++ b/src/views/manage-components-packs/view/components/component-properties.tsx
@@ -1,6 +1,19 @@
-/*
- * Copyright (C) 2025-2026 Arm Limited
+/**
+ * Copyright 2025-2026 Arm Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 import './components-properties.css';
 import React, { useState, useEffect, useCallback } from 'react';
 import { Modal, InputNumber, Dropdown, Button, Space } from 'antd';

--- a/src/views/manage-components-packs/view/components/components-properties.css
+++ b/src/views/manage-components-packs/view/components/components-properties.css
@@ -1,6 +1,19 @@
-/*
- * Copyright (C) 2026 Arm Limited
+/**
+ * Copyright 2026 Arm Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 .manage-component-properties-table tr>td:nth-child(1) {
     white-space: nowrap;
     vertical-align: text-top;

--- a/src/views/manage-components-packs/view/components/components-view.test.tsx
+++ b/src/views/manage-components-packs/view/components/components-view.test.tsx
@@ -1,6 +1,18 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /**
- * Copyright (C) 2026 Arm Limited
+ * Copyright 2026 Arm Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 import 'jest';

--- a/src/views/manage-components-packs/view/components/components-view.tsx
+++ b/src/views/manage-components-packs/view/components/components-view.tsx
@@ -1,5 +1,17 @@
 /**
- * Copyright (C) 2025-2026 Arm Limited
+ * Copyright 2025-2026 Arm Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 import { CloseCircleOutlined, LoadingOutlined } from '@ant-design/icons';

--- a/src/views/manage-components-packs/view/components/draggable-modal-wrapper.css
+++ b/src/views/manage-components-packs/view/components/draggable-modal-wrapper.css
@@ -1,6 +1,19 @@
-/*
- * Copyright (C) 2025-2026 Arm Limited
+/**
+ * Copyright 2025-2026 Arm Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 .draggable-modal-wrapper .ant-modal-header {
     cursor: move;
     position: relative;

--- a/src/views/manage-components-packs/view/components/draggable-modal-wrapper.test.tsx
+++ b/src/views/manage-components-packs/view/components/draggable-modal-wrapper.test.tsx
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Arm Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react';
 import DraggableModalWrapper from './draggable-modal-wrapper';

--- a/src/views/manage-components-packs/view/components/draggable-modal-wrapper.tsx
+++ b/src/views/manage-components-packs/view/components/draggable-modal-wrapper.tsx
@@ -1,6 +1,19 @@
-/*
- * Copyright (C) 2025-2026 Arm Limited
+/**
+ * Copyright 2025-2026 Arm Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 import './draggable-modal-wrapper.css';
 import React from 'react';
 

--- a/src/views/manage-components-packs/view/components/packs-view.css
+++ b/src/views/manage-components-packs/view/components/packs-view.css
@@ -1,5 +1,17 @@
 /**
- * Copyright (C) 2026 Arm Limited
+ * Copyright 2026 Arm Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 .resolve-packs-button {

--- a/src/views/manage-components-packs/view/components/table-renderers/render-description-cell.tsx
+++ b/src/views/manage-components-packs/view/components/table-renderers/render-description-cell.tsx
@@ -1,5 +1,17 @@
 /**
- * Copyright (C) 2025-2026 Arm Limited
+ * Copyright 2025-2026 Arm Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 import '@vscode/codicons/dist/codicon.css';

--- a/src/views/manage-components-packs/view/components/table-renderers/render-edit-field.tsx
+++ b/src/views/manage-components-packs/view/components/table-renderers/render-edit-field.tsx
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Arm Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { ComponentRowDataType } from '../../../data/component-tools';
 import { Button } from 'antd';

--- a/src/views/manage-components-packs/view/components/table-renderers/render-name-cell.tsx
+++ b/src/views/manage-components-packs/view/components/table-renderers/render-name-cell.tsx
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Arm Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from 'react';
 import { ComponentRowDataType } from '../../../data/component-tools';
 import { Tooltip } from 'antd';

--- a/src/views/manage-components-packs/view/components/table-renderers/render-row-selector.tsx
+++ b/src/views/manage-components-packs/view/components/table-renderers/render-row-selector.tsx
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2026 Arm Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { TableRowSelection } from 'antd/es/table/interface';
 import { ComponentRowDataType } from '../../../data/component-tools';
 import { isInActiveLayer } from '../../helpers/components-packs-helpers';

--- a/src/views/manage-components-packs/view/components/table-renderers/render-validation-row.test.tsx
+++ b/src/views/manage-components-packs/view/components/table-renderers/render-validation-row.test.tsx
@@ -1,6 +1,18 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /**
- * Copyright (C) 2026 Arm Limited
+ * Copyright 2026 Arm Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 import 'jest';

--- a/src/views/manage-components-packs/view/components/table-renderers/render-validation-row.tsx
+++ b/src/views/manage-components-packs/view/components/table-renderers/render-validation-row.tsx
@@ -1,5 +1,17 @@
 /**
- * Copyright (C) 2025-2026 Arm Limited
+ * Copyright 2025-2026 Arm Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 import React from 'react';

--- a/src/views/manage-components-packs/view/components/table-renderers/render-variant-cell.tsx
+++ b/src/views/manage-components-packs/view/components/table-renderers/render-variant-cell.tsx
@@ -1,6 +1,19 @@
 /**
- * Copyright (C) 2025-2026 Arm Limited
+ * Copyright 2025-2026 Arm Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
+
 import React from 'react';
 import { ComponentRowDataType } from '../../../data/component-tools';
 import { CompactDropdown } from '../../../../common/components/compact-dropdown';

--- a/src/views/manage-components-packs/view/components/table-renderers/render-warning-cell.tsx
+++ b/src/views/manage-components-packs/view/components/table-renderers/render-warning-cell.tsx
@@ -1,5 +1,17 @@
 /**
- * Copyright (C) 2025-2026 Arm Limited
+ * Copyright 2025-2026 Arm Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 import React, { ComponentState } from 'react';

--- a/src/views/manage-components-packs/view/helpers/components-packs-helpers.tsx
+++ b/src/views/manage-components-packs/view/helpers/components-packs-helpers.tsx
@@ -1,5 +1,17 @@
 /**
- * Copyright (C) 2025-2026 Arm Limited
+ * Copyright 2025-2026 Arm Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 import React from 'react';

--- a/src/views/manage-layers/view/components/create-layer.tsx
+++ b/src/views/manage-layers/view/components/create-layer.tsx
@@ -1,5 +1,17 @@
 /**
- * Copyright (C) 2024-2026 Arm Limited
+ * Copyright 2024-2026 Arm Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 import { VSCodeButton } from '@vscode/webview-ui-toolkit/react';

--- a/src/views/manage-layers/view/components/manage-layers.css
+++ b/src/views/manage-layers/view/components/manage-layers.css
@@ -1,7 +1,19 @@
 @import "../../../common/style/base.css";
 
-/*
- * Copyright (c) 2024-2026 Arm Limited
+/**
+ * Copyright 2024-2026 Arm Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
  .manage-layers-frame {

--- a/src/views/manage-layers/view/components/manage-layers.tsx
+++ b/src/views/manage-layers/view/components/manage-layers.tsx
@@ -1,5 +1,17 @@
 /**
- * Copyright (C) 2023-2026 Arm Limited
+ * Copyright 2023-2026 Arm Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 import { VSCodeButton } from '@vscode/webview-ui-toolkit/react';

--- a/src/views/manage-layers/view/components/validation-message.tsx
+++ b/src/views/manage-layers/view/components/validation-message.tsx
@@ -1,7 +1,18 @@
-/*
- * Copyright (c) 2023-2026 Arm Limited
+/**
+ * Copyright 2023-2026 Arm Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 import * as React from 'react';
 
 export const validationError = (error: string) => error && <div className="input-validation-error"><p>{error}</p></div>;

--- a/src/views/manage-solution/view/components/manage-solution.css
+++ b/src/views/manage-solution/view/components/manage-solution.css
@@ -1,6 +1,18 @@
-/*
-* Copyright (c) 2024-2026 Arm Limited
-*/
+/**
+ * Copyright 2024-2026 Arm Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 @import "../../../common/style/base.css";
 

--- a/src/views/manage-solution/view/components/manage-solution.test.tsx
+++ b/src/views/manage-solution/view/components/manage-solution.test.tsx
@@ -1,5 +1,17 @@
 /**
- * Copyright (C) 2024-2026 Arm Limited
+ * Copyright 2024-2026 Arm Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 import * as React from 'react';

--- a/src/views/manage-solution/view/components/manage-solution.tsx
+++ b/src/views/manage-solution/view/components/manage-solution.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2024-2026 Arm Limited
+ * Copyright 2024-2026 Arm Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/views/manage-solution/view/components/projects-table.test.tsx
+++ b/src/views/manage-solution/view/components/projects-table.test.tsx
@@ -1,5 +1,17 @@
 /**
- * Copyright (C) 2024-2026 Arm Limited
+ * Copyright 2024-2026 Arm Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 import * as React from 'react';

--- a/src/views/manage-solution/view/components/projects-table.tsx
+++ b/src/views/manage-solution/view/components/projects-table.tsx
@@ -1,5 +1,17 @@
 /**
- * Copyright (C) 2024-2026 Arm Limited
+ * Copyright 2024-2026 Arm Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 import * as React from 'react';

--- a/src/views/manage-solution/view/components/targets-table.test.tsx
+++ b/src/views/manage-solution/view/components/targets-table.test.tsx
@@ -1,5 +1,17 @@
 /**
- * Copyright (C) 2024-2026 Arm Limited
+ * Copyright 2024-2026 Arm Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 import * as React from 'react';

--- a/src/views/manage-solution/view/components/targets-table.tsx
+++ b/src/views/manage-solution/view/components/targets-table.tsx
@@ -1,5 +1,17 @@
 /**
- * Copyright (C) 2024-2026 Arm Limited
+ * Copyright 2024-2026 Arm Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 import * as React from 'react';


### PR DESCRIPTION
## Changes
- Extended `copyright:check` script to look for *.tsx and *.css file as well.
- Updated copyright notice header is respective files

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [x] 🤖 This change is covered by unit tests (if applicable).
- [x] 🤹 Manual testing has been performed (if necessary).
- [x] 🛡️ Security impacts have been considered (if relevant).
- [x] 📖 Documentation updates are complete (if required).
- [x] 🧠 Third-party dependencies and TPIP updated (if required).
