### PR TITLE
Keep explicitly closed solutions closed on workspace open

### DIFF
--- a/src/solutions/active-solution-tracker.test.ts
+++ b/src/solutions/active-solution-tracker.test.ts
@@ -224,6 +224,37 @@ describe('ActiveSolutionTracker', () => {
         });
     });
 
+    describe('activated with solutions in the workspace and explicit previous close', () => {
+        beforeEach(async () => {
+            context.workspaceState.get.mockImplementation(
+                key => key === ActiveSolutionTrackerImpl.ACTIVE_SOLUTION_STATE_KEY ? 'inactive'  : undefined
+            );
+
+            activeSolutionTracker.activate(context as unknown as vscode.ExtensionContext);
+            await waitForCondition(
+                async () => workspaceFoldersProvider.findFiles.mock.calls.length > 0,
+                'solution file search to complete in empty workspace',
+                200,
+            );
+        });
+
+        it('selects no solution as active', () => {
+            expect(activeSolutionTracker.solutions).toEqual([
+                SOLUTION_URI_BAR.fsPath,
+                SOLUTION_URI_FOO.fsPath,
+                SOLUTION_URI_DEFAULT.fsPath,
+            ]);
+
+            expect(activeSolutionTracker.activeSolution).toBeUndefined();
+            expect(changeActiveListener).not.toHaveBeenCalled();
+            expect(changeSolutionsListener).toHaveBeenCalled();
+        });
+
+        it('updates ACTIVE_SOLUTION_STATE to inactive', () => {
+            expect(commandsProvider.executeCommand).toHaveBeenCalledWith('setContext', ActiveSolutionTrackerImpl.ACTIVE_SOLUTION_STATE, 'inactive');
+        });
+    });
+
     describe('activated with solutions in workspace subfolders only', () => {
         beforeEach(async () => {
             workspaceFoldersProvider.findFiles.mockResolvedValue([

--- a/src/solutions/active-solution-tracker.ts
+++ b/src/solutions/active-solution-tracker.ts
@@ -88,12 +88,15 @@ export interface ActiveSolutionTracker {
     suspendWatch: boolean;
 }
 
+type SolutionState = 'active' | 'inactive' | 'none';
+
 export class ActiveSolutionTrackerImpl implements ActiveSolutionTracker {
     public static readonly GLOB_PATTERN = '**/*.csolution.{yaml,yml}';
 
     public static readonly ACTIVE_SOLUTION_KEY = 'activeSolution';
-    public static readonly ACTIVE_SOLUTION_STATE = `${manifest.PACKAGE_NAME}.activeSolutionState`;
-    public static readonly ACTIVE_SOLUTION = `${manifest.PACKAGE_NAME}.activeSolution`;
+    public static readonly ACTIVE_SOLUTION_STATE_KEY = 'activeSolutionState';
+    public static readonly ACTIVE_SOLUTION_STATE = `${manifest.PACKAGE_NAME}.${ActiveSolutionTrackerImpl.ACTIVE_SOLUTION_STATE_KEY}`;
+    public static readonly ACTIVE_SOLUTION = `${manifest.PACKAGE_NAME}.${ActiveSolutionTrackerImpl.ACTIVE_SOLUTION_KEY}`;
 
     private readonly changeSolutionsEmitter = new vscode.EventEmitter<void>();
     public readonly onDidChangeSolutions: vscode.Event<void> = this.changeSolutionsEmitter.event;
@@ -192,13 +195,16 @@ export class ActiveSolutionTrackerImpl implements ActiveSolutionTracker {
             this.changeSolutionsEmitter.fire();
         }
 
-        const previous = this._activeSolution || this.workspaceState?.get<string | undefined>(ActiveSolutionTrackerImpl.ACTIVE_SOLUTION_KEY);
+        const previous = this._activeSolution || this.workspaceState?.get<string>(ActiveSolutionTrackerImpl.ACTIVE_SOLUTION_KEY);
+        const previousState = this.workspaceState?.get<SolutionState>(ActiveSolutionTrackerImpl.ACTIVE_SOLUTION_STATE_KEY);
 
         if (previous && this.solutions.includes(previous)) {
             this.activeSolution = previous;
-        } else {
+        } else if (previousState === undefined || previousState === 'active') {
             const defaultSolution = this._solutions?.find(s => path.dirname(s) === this.workspaceFoldersProvider.getWorkspaceFolder(s)?.uri?.fsPath);
             this.activeSolution = defaultSolution;
+        } else {
+            this.activeSolution = undefined;
         }
     }
 
@@ -210,9 +216,10 @@ export class ActiveSolutionTrackerImpl implements ActiveSolutionTracker {
         return this._activeSolution;
     }
 
-    protected set activeSolutionState(state: 'active' | 'inactive' | 'none') {
-        const newState = this._solutions?.length > 0 ? state : 'none';
+    protected set activeSolutionState(state: SolutionState) {
+        const newState: SolutionState = this._solutions?.length > 0 ? state : 'none';
         this.commandsProvider.executeCommand('setContext', ActiveSolutionTrackerImpl.ACTIVE_SOLUTION_STATE, newState);
+        this.workspaceState?.update(ActiveSolutionTrackerImpl.ACTIVE_SOLUTION_STATE_KEY, newState);
     }
 
     public set activeSolution(newPath: string | undefined) {


### PR DESCRIPTION

## Fixes
<!-- List the GitHub issue this PR resolves -->
- Open-CMSIS-Pack/vscode-cmsis-solution#191 number 5
- Overlaps with #193 

## Changes
<!-- List the changes this PR introduces -->
- Record solution load state in workspace memento
- Skip loading default solution if load state was explicitly set to `inactive` (i.e., closed)

## Screenshots
<!-- Show UI changes with screenshots to ease UX/UI feedback: -->

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [x] 🤖 This change is covered by unit tests (if applicable).
- [x] 🤹 Manual testing has been performed (if necessary).
- [x] 🛡️ Security impacts have been considered (if relevant).
- [x] 📖 Documentation updates are complete (if required).
- [x] 🧠 Third-party dependencies and TPIP updated (if required).
