### PR TITLE
Call RPC resolve with layer path if needed

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "csolution": {
     "uv2csolutionVersion": "1.6.0",
     "toolboxVersion": "nightly",
-    "rpcVersion": "0.0.9"
+    "rpcVersion": "0.0.10"
   },
   "scripts": {
     "preprepare": "npm run download:rpc-interface",

--- a/src/views/manage-components-packs/components-packs-webview-main.test.ts
+++ b/src/views/manage-components-packs/components-packs-webview-main.test.ts
@@ -1621,7 +1621,35 @@ describe('ComponentsPacksWebviewMain', () => {
             await (componentsPacksWebviewMain as any).resolveComponents();
 
             expect(resolveMock).toHaveBeenCalledTimes(1);
-            expect(resolveMock).toHaveBeenCalledWith({ context: 'ctx1' });
+            expect(resolveMock).toHaveBeenCalledWith({
+                context: 'ctx1',
+                options: {
+                    layer: '',
+                    explicitVersion: '',
+                    explicitVendor: false,
+                },
+            });
+        });
+
+        it('passes selected layer path to resolve options when selected target is a layer', async () => {
+            (componentsPacksWebviewMain as any).selectedContext = {
+                label: 'Layer: App',
+                key: 'layer-key',
+                path: 'layers/app.clayer.yml',
+                relativePath: 'layers/app.clayer.yml',
+                type: 'layer',
+            };
+
+            await (componentsPacksWebviewMain as any).resolveComponents();
+
+            expect(resolveMock).toHaveBeenCalledWith({
+                context: 'ctx1',
+                options: {
+                    layer: 'layers/app.clayer.yml',
+                    explicitVersion: '',
+                    explicitVendor: false,
+                },
+            });
         });
 
         it('calls getComponentsTree with active context and scope', async () => {

--- a/src/views/manage-components-packs/components-packs-webview-main.ts
+++ b/src/views/manage-components-packs/components-packs-webview-main.ts
@@ -827,7 +827,16 @@ export class ComponentsPacksWebviewMain {
 
     private async resolveComponents(): Promise<void> {
         const activeContext = this.getActiveContext();
-        await this.csolutionService.resolve({ context: activeContext });
+        const selectedTarget = this.getSelectedTargetSetData();
+        const selectedLayerPath = selectedTarget?.type === 'layer' ? selectedTarget.path : '';
+        await this.csolutionService.resolve({
+            context: activeContext,
+            options: {
+                layer: selectedLayerPath,
+                explicitVersion: '',
+                explicitVendor: false,
+            },
+        });
         await this.sendSolutionData();
         await this.sendDirtyState();
     };


### PR DESCRIPTION
## Fixes
<!-- List the GitHub issue this PR resolves -->
- #213 

## Changes
<!-- List the changes this PR introduces -->
- If a layer is selected, send its path via options to Resolve RPC call


## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [ ] 🤖 This change is covered by unit tests (if applicable).
- [ ] 🤹 Manual testing has been performed (if necessary).
- [ ] 🛡️ Security impacts have been considered (if relevant).
- [ ] 📖 Documentation updates are complete (if required).
- [ ] 🧠 Third-party dependencies and TPIP updated (if required).
