### PR TITLE
Fix header/row alignment on very wide ellipsis cells and remove overflow: hidden mode on dropdown cells.

### DIFF
--- a/src/views/manage-components-packs/view/components/component-pack-manager.css
+++ b/src/views/manage-components-packs/view/components/component-pack-manager.css
@@ -46,6 +46,10 @@
     cursor: default;
 }
 
+.ant-table-cell-ellipsis {
+    max-width: 50vw;
+}
+
 .faded {
     opacity: 0.5;
     margin-left: 0.5em;
@@ -252,6 +256,10 @@ th.ant-table-cell {
 
 .components-view-root th.ant-table-cell:nth-child(2) {
     text-indent: -10px;
+}
+
+.components-view-root .ant-table-cell:nth-child(6) {
+    overflow: unset;
 }
 
 .packs-view-root .expandable-references {

--- a/src/views/manage-components-packs/view/components/component-pack-manager.css
+++ b/src/views/manage-components-packs/view/components/component-pack-manager.css
@@ -46,8 +46,8 @@
     cursor: default;
 }
 
-.ant-table-cell-ellipsis {
-    max-width: 50vw;
+.components-view-root .description-column {
+    max-width: 55vw;
 }
 
 .faded {
@@ -258,8 +258,8 @@ th.ant-table-cell {
     text-indent: -10px;
 }
 
-.components-view-root .ant-table-cell:nth-child(6) {
-    overflow: unset;
+.variant-column {
+    overflow: unset !important;
 }
 
 .packs-view-root .expandable-references {

--- a/src/views/manage-components-packs/view/components/components-view.tsx
+++ b/src/views/manage-components-packs/view/components/components-view.tsx
@@ -125,10 +125,10 @@ export const ComponentsView: React.FC<ComponentsViewProps> = ({
         { title: '', width: 40, render: (record: ComponentRowDataType) => renderWarningCell(record, state) },
         Table.SELECTION_COLUMN,
         { title: '', width: 40, render: (record: ComponentRowDataType) => renderEditField(record, setSelectedComponent, state) },
-        { title: 'Variant', dataIndex: ['parsed', 'variant'], key: 'variant', minWidth: 60, maxWidth: 90, ellipsis: true, render: (value: string, record: ComponentRowDataType, index: number) => renderVariantCell(value, record, index, onChangeBundle, onChangeComponentVariant) },
+        { title: 'Variant', dataIndex: ['parsed', 'variant'], key: 'variant', minWidth: 60, maxWidth: 90, ellipsis: true, render: (value: string, record: ComponentRowDataType, index: number) => renderVariantCell(value, record, index, onChangeBundle, onChangeComponentVariant), onCell: () => ({ className: 'variant-column' }) },
         { title: 'Version', dataIndex: ['parsed', 'version'], key: 'version', minWidth: 60, ellipsis: false },
         { title: 'Vendor', dataIndex: ['parsed', 'vendor'], key: 'vendor', minWidth: 60, ellipsis: false },
-        { title: 'Description', dataIndex: ['data', 'description'], key: 'data.description', width: 'calc(fit-content - 50px)', ellipsis: true, render: (value: string, record: ComponentRowDataType) => renderDescriptionCell(value, record, state, openDocFile) },
+        { title: 'Description', dataIndex: ['data', 'description'], key: 'data.description', width: 'calc(fit-content - 50px)', ellipsis: true, render: (value: string, record: ComponentRowDataType) => renderDescriptionCell(value, record, state, openDocFile), onCell: () => ({ className: 'description-column' }) },
     ], [openFile, state, onChangeBundle, onChangeComponentVariant, openDocFile]);
 
 

--- a/src/views/manage-components-packs/view/components/packs-view.css
+++ b/src/views/manage-components-packs/view/components/packs-view.css
@@ -52,3 +52,7 @@
     color: var(--vscode-foreground);
     vertical-align: text-bottom;
 }
+
+.packs-view-root .description-column {
+    max-width: 65vw;
+}

--- a/src/views/manage-components-packs/view/components/packs-view.tsx
+++ b/src/views/manage-components-packs/view/components/packs-view.tsx
@@ -162,7 +162,7 @@ export const PacksView: React.FC<PacksProps> = ({ state, openFile, messageHandle
             { title: 'Software Pack', dataIndex: 'name', key: 'name', width: 240, ellipsis: true, render: renderPackColumn },
             { title: 'Select', render: (record: PackRowDataType) => renderEditColumn(record), width: 64 },
             { title: 'Version', dataIndex: 'versionTarget', key: 'versionTarget', minWidth: 120, ellipsis: false, render: renderVersionTarget },
-            { title: 'Description', dataIndex: 'description', key: 'description', ellipsis: true, render: renderDescriptionCell },
+            { title: 'Description', dataIndex: 'description', key: 'description', ellipsis: true, render: renderDescriptionCell, onCell: () => ({ className: 'description-column' }) },
         ];
     }, [openFile, selectPack]);
 

--- a/src/views/manage-components-packs/view/components/table-renderers/render-variant-cell.tsx
+++ b/src/views/manage-components-packs/view/components/table-renderers/render-variant-cell.tsx
@@ -51,7 +51,6 @@ export const renderVariantCell = (
     };
 
     return (
-
         <CompactDropdown
             available={menuItems.map(item => item.key)}
             selected={value || defaultLabel}


### PR DESCRIPTION


## Fixes
<!-- List the GitHub issue this PR resolves -->
- [#216](https://github.com/Open-CMSIS-Pack/vscode-cmsis-solution/issues/216)

## Changes
<!-- List the changes this PR introduces -->
- Fix variant column cell to not have an overflow: hidden mode
- Fix very wide ellipsis column cells to break header/row alignment by restricting them to maximum 50vw (viewport width)

## Screenshots
<!-- Show UI changes with screenshots to ease UX/UI feedback: -->
<img width="550" height="218" alt="image" src="https://github.com/user-attachments/assets/76fdb1d2-fad4-41b1-a60c-9f35d0481ab9" />

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [ ] 🤖 This change is covered by unit tests (if applicable).
- [ ] 🤹 Manual testing has been performed (if necessary).
- [ ] 🛡️ Security impacts have been considered (if relevant).
- [ ] 📖 Documentation updates are complete (if required).
- [ ] 🧠 Third-party dependencies and TPIP updated (if required).
