### PR TITLE
Fix pack links: show only in tooltips

### DIFF
--- a/src/views/manage-components-packs/view/components/packs-view.tsx
+++ b/src/views/manage-components-packs/view/components/packs-view.tsx
@@ -102,15 +102,11 @@ export const PacksView: React.FC<PacksProps> = ({ state, openFile, messageHandle
                 })) ?? []
             ];
 
-            const tooltipTitle = record.references && record.references.length > 0
-                ? referencedFrom
-                : [<div key='pack-name'>{packTitle}</div>];
-
             return (
                 <div className='pack-name-cell'>
                     <span>
                         <Tooltip
-                            title={tooltipTitle}
+                            title={referencedFrom}
                             placement='bottomLeft'
                         >
                             <span>{record.name}</span>

--- a/src/views/manage-components-packs/view/components/packs-view.tsx
+++ b/src/views/manage-components-packs/view/components/packs-view.tsx
@@ -102,18 +102,19 @@ export const PacksView: React.FC<PacksProps> = ({ state, openFile, messageHandle
                 })) ?? []
             ];
 
+            const tooltipTitle = record.references && record.references.length > 0
+                ? referencedFrom
+                : [<div key='pack-name'>{packTitle}</div>];
+
             return (
                 <div className='pack-name-cell'>
                     <span>
-                        {record.references && record.references.length > 0 ? (
-                            <Tooltip title={referencedFrom} placement='bottomLeft'>
-                                <span>{record.name}</span>
-                            </Tooltip>
-                        ) : (
-                            <Tooltip title={record.name}>
-                                {packTitle}
-                            </Tooltip>
-                        )}
+                        <Tooltip
+                            title={tooltipTitle}
+                            placement='bottomLeft'
+                        >
+                            <span>{record.name}</span>
+                        </Tooltip>
                     </span>
                 </div>
             );


### PR DESCRIPTION

## Fixes
<!-- List the GitHub issue this PR resolves -->
- #181 
- #195 

## Changes
<!-- List the changes this PR introduces -->
- unwanted extra link in a pack name cell is removed
- 
## Screenshots
<!-- Show UI changes with screenshots to ease UX/UI feedback: -->
<img width="2733" height="1761" alt="image" src="https://github.com/user-attachments/assets/35352141-9390-4ee2-834e-c035fac1e628" />

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [x] 🤖 This change is covered by unit tests (if applicable).
- [x] 🤹 Manual testing has been performed (if necessary).
- [ ] 🛡️ Security impacts have been considered (if relevant).
- [ ] 📖 Documentation updates are complete (if required).
- [ ] 🧠 Third-party dependencies and TPIP updated (if required).
