### PR TITLE
Add active/inactive layer styles and update row class logic for selection feedback

### DIFF
--- a/src/views/manage-components-packs/view/components/component-pack-manager.css
+++ b/src/views/manage-components-packs/view/components/component-pack-manager.css
@@ -297,6 +297,7 @@ th.ant-table-cell {
     vertical-align: unset;
 }
 
+
 .packs-view-root tr td:first-child,
 .packs-view-root tr th:first-child {
     padding-left: 24px !important;
@@ -304,4 +305,13 @@ th.ant-table-cell {
 
 .packs-view-root .ant-table-wrapper {
     padding-top: 4px;
+}
+
+.active-layer {
+    background-color: var(--vscode-editor-activeSelectionBackground);
+}
+
+.inactive-layer {
+    background-color: var(--vscode-editor-inactiveSelectionBackground);
+    opacity: 0.5;
 }

--- a/src/views/manage-components-packs/view/components/packs-view.css
+++ b/src/views/manage-components-packs/view/components/packs-view.css
@@ -56,3 +56,12 @@
 .packs-view-root .description-column {
     max-width: 65vw;
 }
+
+.active-layer {
+    background-color: var(--vscode-editor-activeSelectionBackground);
+}
+
+.inactive-layer {
+    background-color: var(--vscode-editor-inactiveSelectionBackground);
+    opacity: 0.5;
+}

--- a/src/views/manage-components-packs/view/components/packs-view.tsx
+++ b/src/views/manage-components-packs/view/components/packs-view.tsx
@@ -226,7 +226,7 @@ export const PacksView: React.FC<PacksProps> = ({ state, openFile, messageHandle
         const relativePath = state.selectedTargetType?.relativePath || '';
         const selectedInCurrentTarget = referenceFromContext(relativePath, record).length > 0;
 
-        return !selectedInCurrentTarget ? '' : 'ant-table-row-disabled';
+        return selectedInCurrentTarget ? 'active-layer' : 'inactive-layer';
     };
 
     return (

--- a/src/views/manage-components-packs/view/helpers/components-packs-helpers.tsx
+++ b/src/views/manage-components-packs/view/helpers/components-packs-helpers.tsx
@@ -113,7 +113,10 @@ export const isInActiveLayer = (record: ComponentRowDataType, state: { activeLay
 export const rowClassName = (record: ComponentRowDataType, state: { activeLayer?: string, selectedTargetType: TargetSetData | undefined }): string => {
     const isLeaf = !(record.children && record.children.length);
     const inActiveLayer = isInActiveLayer(record, state);
-    return `${isLeaf ? 'leaf-node ' : ''}${!inActiveLayer ? 'active-layer ' : 'ant-table-row-disabled '}`.trim();
+    const selectable = inActiveLayer
+        || !record.aggregate?.options?.layer!.length
+        || record.aggregate?.options?.layer === getActiveLayer(state);
+    return `${isLeaf ? 'leaf-node ' : ''}${selectable ? 'active-layer ' : 'inactive-layer '}`.trim();
 };
 
 export const codiconIcon = (name: string, title?: string, color?: string): React.ReactNode => {


### PR DESCRIPTION
To prevent confusion for selected/selectable components, dimming a component row depends now on how the component can be interacted with. 

Components selected in the current layer or not selected at all, are selectable and therefore enabled.

Components selected in a layer other than the current aren't selectable for this layer and therefore disabled. A disabled component must be visually disabled, as well.

## Fixes
<!-- List the GitHub issue this PR resolves -->
- [#<issue-number>](https://github.com/Open-CMSIS-Pack/vscode-cmsis-solution/issues/<issue-number>)

## Changes
<!-- List the changes this PR introduces -->
-

## Screenshots
<!-- Show UI changes with screenshots to ease UX/UI feedback: -->

| Dark Theme | Light Theme |
|--------|--------|
| Components | Components|
| <img width="537" height="329" alt="image" src="https://github.com/user-attachments/assets/1b1eee3f-b8c7-4863-bacb-3b76e8cd2f57" /> | <img width="608" height="317" alt="image" src="https://github.com/user-attachments/assets/86ab1b80-dde5-42a6-8760-a2e53f5cfeea" /> |
| Software Packs | Software Packs |
| <img width="571" height="317" alt="image" src="https://github.com/user-attachments/assets/03242146-b8dd-4fe3-aff5-7d11d28cc7a7" /> | <img width="564" height="288" alt="image" src="https://github.com/user-attachments/assets/84983f57-faf4-4fd0-8600-2f2caf89e43f" /> | 

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [ ] 🤖 This change is covered by unit tests (if applicable).
- [ ] 🤹 Manual testing has been performed (if necessary).
- [ ] 🛡️ Security impacts have been considered (if relevant).
- [ ] 📖 Documentation updates are complete (if required).
- [ ] 🧠 Third-party dependencies and TPIP updated (if required).
