### PR TITLE
Remove Link checker output on GH summary page

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           args: --config .github/lychee.toml './**/*.md'
           fail: true
-          jobSummary: true
+          jobSummary: false
 
   build:
     if: github.repository == 'Open-CMSIS-Pack/vscode-cmsis-solution'


### PR DESCRIPTION
## Changes

- Removed printing of the summary on GitHub summary as it was too verbose. The same info can be obtained from action logs


## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [x] 🤖 This change is covered by unit tests (if applicable).
- [x] 🤹 Manual testing has been performed (if necessary).
- [x] 🛡️ Security impacts have been considered (if relevant).
- [x] 📖 Documentation updates are complete (if required).
- [x] 🧠 Third-party dependencies and TPIP updated (if required).
