### PR TITLE
RPC: request refresh after LoadPacks

### DIFF
--- a/src/json-rpc/csolution-rpc-client.factory.ts
+++ b/src/json-rpc/csolution-rpc-client.factory.ts
@@ -34,6 +34,8 @@ export const csolutionServiceFactory = makeFactory<
     listMissingPacks: () => jest.fn(),
     getCsolutionBin: () => jest.fn(),
     waitForExit: () => jest.fn(),
+    suspendPackIdxWatcher: () => jest.fn(),
+    resumePackIdxWatcher: () => jest.fn(),
     selectPack: () => jest.fn(),
     getVariables: () => jest.fn(),
 });

--- a/src/json-rpc/csolution-rpc-client.ts
+++ b/src/json-rpc/csolution-rpc-client.ts
@@ -31,6 +31,8 @@ export interface CsolutionService extends RpcInterface {
     activate(context: Pick<vscode.ExtensionContext, 'subscriptions'>): Promise<void>;
     getCsolutionBin(): string;
     waitForExit(): Promise<void>;
+    suspendPackIdxWatcher(): void;
+    resumePackIdxWatcher(): void;
 }
 
 class CsolutionServiceImpl extends RpcMethods implements CsolutionService {
@@ -44,6 +46,8 @@ class CsolutionServiceImpl extends RpcMethods implements CsolutionService {
     private csolutionBin = 'csolution';
     private exitPromise: Promise<void> | undefined;
     private cachedVersion: GetVersionResult = { success: false };
+    private packIdxWatcherSuspendDepth = 0;
+    private pendingPackIdxChange = false;
     private readonly mutex: Mutex;
 
     constructor(
@@ -105,6 +109,20 @@ class CsolutionServiceImpl extends RpcMethods implements CsolutionService {
         return this.exitPromise ?? Promise.resolve();
     }
 
+    public suspendPackIdxWatcher(): void {
+        this.packIdxWatcherSuspendDepth++;
+    }
+
+    public resumePackIdxWatcher(): void {
+        if (this.packIdxWatcherSuspendDepth > 0) {
+            this.packIdxWatcherSuspendDepth--;
+        }
+        if (this.packIdxWatcherSuspendDepth === 0 && this.pendingPackIdxChange) {
+            this.pendingPackIdxChange = false;
+            this.debouncedLoadPacks();
+        }
+    }
+
     private watchPackIdxFile() {
         this.idxWatcher?.close();
         const pack_idx = path.join(getCmsisPackRoot(), 'pack.idx');
@@ -114,6 +132,10 @@ class CsolutionServiceImpl extends RpcMethods implements CsolutionService {
                 const stat = fs.statSync(pack_idx);
                 if (stat?.mtimeMs !== mtimeMs) {
                     mtimeMs = stat.mtimeMs;
+                    if (this.packIdxWatcherSuspendDepth > 0) {
+                        this.pendingPackIdxChange = true;
+                        return;
+                    }
                     this.debouncedLoadPacks();
                 }
             }

--- a/src/json-rpc/csolution-rpc-client.ts
+++ b/src/json-rpc/csolution-rpc-client.ts
@@ -40,7 +40,7 @@ class CsolutionServiceImpl extends RpcMethods implements CsolutionService {
     private child: ChildProcess | undefined;
     private connection: MessageConnection | undefined;
     private idxWatcher: Optional<fs.FSWatcher> = undefined;
-    private readonly debouncedLoadPacks = debounce(super.loadPacks.bind(this), 1000);
+    private readonly debouncedLoadPacks = debounce(this.loadPacks.bind(this), 1000);
     private csolutionBin = 'csolution';
     private exitPromise: Promise<void> | undefined;
     private cachedVersion: GetVersionResult = { success: false };
@@ -57,9 +57,9 @@ class CsolutionServiceImpl extends RpcMethods implements CsolutionService {
     public async activate(context: vscode.ExtensionContext) {
         context.subscriptions.push(
             this,
-            this.commandsProvider.registerCommand(CsolutionServiceImpl.reloadPacksCommandId, this.loadPacks, this),
+            this.commandsProvider.registerCommand(CsolutionServiceImpl.reloadPacksCommandId, this.reloadPacks, this),
         );
-        this.loadPacks();
+        this.loadPacks(); // direct load without notification
     }
 
     public async dispose() {
@@ -87,8 +87,14 @@ class CsolutionServiceImpl extends RpcMethods implements CsolutionService {
         }
         // ensure version is cached
         await this.getVersion();
-
         return super.loadPacks();
+    }
+
+
+    private async reloadPacks() {
+        const result = await this.loadPacks();
+        void this.commandsProvider.executeCommand(manifest.REFRESH_COMMAND_ID);
+        return result;
     }
 
     public getCsolutionBin(): string {

--- a/src/json-rpc/csolution-rpc-client.ts
+++ b/src/json-rpc/csolution-rpc-client.ts
@@ -32,7 +32,7 @@ export interface CsolutionService extends RpcInterface {
     getCsolutionBin(): string;
     waitForExit(): Promise<void>;
     suspendPackIdxWatcher(): void;
-    resumePackIdxWatcher(): void;
+    resumePackIdxWatcher(skipPendingReload?: boolean): void;
 }
 
 class CsolutionServiceImpl extends RpcMethods implements CsolutionService {
@@ -42,7 +42,7 @@ class CsolutionServiceImpl extends RpcMethods implements CsolutionService {
     private child: ChildProcess | undefined;
     private connection: MessageConnection | undefined;
     private idxWatcher: Optional<fs.FSWatcher> = undefined;
-    private readonly debouncedLoadPacks = debounce(this.loadPacks.bind(this), 1000);
+    private readonly debouncedLoadPacks = debounce(this.reloadPacks.bind(this), 1000);
     private csolutionBin = 'csolution';
     private exitPromise: Promise<void> | undefined;
     private cachedVersion: GetVersionResult = { success: false };
@@ -113,9 +113,12 @@ class CsolutionServiceImpl extends RpcMethods implements CsolutionService {
         this.packIdxWatcherSuspendDepth++;
     }
 
-    public resumePackIdxWatcher(): void {
+    public resumePackIdxWatcher(skipPendingReload: boolean = false): void {
         if (this.packIdxWatcherSuspendDepth > 0) {
             this.packIdxWatcherSuspendDepth--;
+        }
+        if (skipPendingReload) {
+            this.pendingPackIdxChange = false;
         }
         if (this.packIdxWatcherSuspendDepth === 0 && this.pendingPackIdxChange) {
             this.pendingPackIdxChange = false;

--- a/src/json-rpc/csolution-rpc-helper.test.ts
+++ b/src/json-rpc/csolution-rpc-helper.test.ts
@@ -411,6 +411,28 @@ describe('csolution-rpc-client', () => {
             expect(prevClose).toHaveBeenCalledTimes(1);
             expect(fs.watch).toHaveBeenCalledTimes(1);
         });
+
+        it('suppresses pack.idx-triggered reload while suspended and runs once after resume', () => {
+            let watcherCallback: ((eventType: string) => void) | undefined;
+
+            (fs.statSync as unknown as jest.Mock)
+                .mockReturnValueOnce({ mtimeMs: 40 }) // initial
+                .mockReturnValueOnce({ mtimeMs: 41 }); // changed
+
+            (fs.watch as unknown as jest.Mock).mockImplementation((_file: string, listener: any) => {
+                watcherCallback = listener;
+                return { close: jest.fn() };
+            });
+
+            service.watchPackIdxFile();
+            service.suspendPackIdxWatcher();
+
+            watcherCallback!('change');
+            expect(service.debouncedLoadPacks).not.toHaveBeenCalled();
+
+            service.resumePackIdxWatcher();
+            expect(service.debouncedLoadPacks).toHaveBeenCalledTimes(1);
+        });
     });
 
     describe('csolution-rpc-client launch', () => {

--- a/src/json-rpc/csolution-rpc-helper.test.ts
+++ b/src/json-rpc/csolution-rpc-helper.test.ts
@@ -13,6 +13,7 @@ import { CsolutionService } from './csolution-rpc-client';
 import { splitBoardId, splitDeviceId, splitPackId } from './csolution-rpc-helper';
 import { VcpkgManager } from '../vcpkg/vcpkg-manager';
 import { Environment, EnvironmentManager } from '../desktop/env-manager';
+import * as manifest from '../manifest';
 
 jest.mock('node:child_process', () => ({
     ...jest.requireActual('node:child_process'),
@@ -28,12 +29,16 @@ jest.mock('vscode-jsonrpc/node', () => ({
 describe('csolution-rpc-client', () => {
     type AnyService = Record<string, any>;
 
-    function createService(envManager?: EnvironmentManager): AnyService {
+    function createService(envManager?: EnvironmentManager, commandsProvider?: AnyService): AnyService {
         // `constructor(...)` wrapper shape is repo-specific; treat as constructible in tests.
         const mockEnvManager = envManager ?? ({
             augmentEnv: jest.fn().mockReturnValue(new Environment({}))
         } as unknown as EnvironmentManager);
-        return new (CsolutionService as unknown as new (em: EnvironmentManager) => AnyService)(mockEnvManager);
+        const mockCommandsProvider = commandsProvider ?? ({
+            executeCommand: jest.fn().mockResolvedValue(undefined),
+            registerCommand: jest.fn(),
+        });
+        return new (CsolutionService as unknown as new (em: EnvironmentManager, cp: AnyService) => AnyService)(mockEnvManager, mockCommandsProvider);
     }
 
     beforeEach(() => {
@@ -264,6 +269,31 @@ describe('csolution-rpc-client', () => {
             expect(transceiveSpy).toHaveBeenCalledWith('GetVersion', undefined);
             expect(transceiveSpy).toHaveBeenCalledWith('LoadPacks', undefined);
             expect(sequence.indexOf('GetVersion')).toBeLessThan(sequence.indexOf('LoadPacks'));
+            expect(service.commandsProvider.executeCommand).not.toHaveBeenCalled();
+        });
+
+        it('does not await refresh command execution in reloadPacks', async () => {
+            const neverResolves = new Promise<void>(() => undefined);
+            service = createService(undefined, {
+                executeCommand: jest.fn().mockReturnValue(neverResolves),
+                registerCommand: jest.fn(),
+            });
+            service.idxWatcher = { close: jest.fn() };
+            jest.spyOn(service as any, 'transceive').mockImplementation(async (...args: unknown[]) => {
+                const method = String(args[0]);
+                if (method === 'GetVersion') {
+                    return { success: true, version: '1.2.3', apiVersion: '0.0.9' };
+                }
+                if (method === 'LoadPacks') {
+                    return { success: true };
+                }
+                return { success: false };
+            });
+
+            const result = await service.reloadPacks();
+
+            expect(result).toEqual({ success: true });
+            expect(service.commandsProvider.executeCommand).toHaveBeenCalledWith(manifest.REFRESH_COMMAND_ID);
         });
     });
 

--- a/src/json-rpc/csolution-rpc-helper.test.ts
+++ b/src/json-rpc/csolution-rpc-helper.test.ts
@@ -433,6 +433,50 @@ describe('csolution-rpc-client', () => {
             service.resumePackIdxWatcher();
             expect(service.debouncedLoadPacks).toHaveBeenCalledTimes(1);
         });
+
+        it('can resume without running pending reload when skipPendingReload is true', () => {
+            let watcherCallback: ((eventType: string) => void) | undefined;
+
+            (fs.statSync as unknown as jest.Mock)
+                .mockReturnValueOnce({ mtimeMs: 50 }) // initial
+                .mockReturnValueOnce({ mtimeMs: 51 }); // changed
+
+            (fs.watch as unknown as jest.Mock).mockImplementation((_file: string, listener: any) => {
+                watcherCallback = listener;
+                return { close: jest.fn() };
+            });
+
+            service.watchPackIdxFile();
+            service.suspendPackIdxWatcher();
+
+            watcherCallback!('change');
+            expect(service.debouncedLoadPacks).not.toHaveBeenCalled();
+
+            service.resumePackIdxWatcher(true);
+            expect(service.debouncedLoadPacks).not.toHaveBeenCalled();
+        });
+
+        it('triggers pending reload when resuming with depth already zero', () => {
+            service.pendingPackIdxChange = true;
+            service.packIdxWatcherSuspendDepth = 0;
+
+            service.resumePackIdxWatcher();
+
+            expect(service.debouncedLoadPacks).toHaveBeenCalledTimes(1);
+            expect(service.pendingPackIdxChange).toBe(false);
+            expect(service.packIdxWatcherSuspendDepth).toBe(0);
+        });
+
+        it('is a no-op when resuming with depth zero and no pending change', () => {
+            service.pendingPackIdxChange = false;
+            service.packIdxWatcherSuspendDepth = 0;
+
+            service.resumePackIdxWatcher();
+
+            expect(service.debouncedLoadPacks).not.toHaveBeenCalled();
+            expect(service.pendingPackIdxChange).toBe(false);
+            expect(service.packIdxWatcherSuspendDepth).toBe(0);
+        });
     });
 
     describe('csolution-rpc-client launch', () => {

--- a/src/solutions/cmsis-toolbox.factories.ts
+++ b/src/solutions/cmsis-toolbox.factories.ts
@@ -30,6 +30,8 @@ export const cmsisToolboxManagerFactory = (): MockCmsisToolboxManager => {
         runCmsisTool: jest.fn().mockResolvedValue([0, undefined]),
         runCsolutionRpc: jest.fn().mockResolvedValue({ success: true }),
         isRunning: jest.fn(),
+        suspendPackReload: jest.fn(),
+        resumePackReload: jest.fn(),
         collectSetupMessages: jest.fn(),
         getSetupMessages: jest.fn(),
         onRunCmsisTool: onRunCmsisToolEventEmitter.event,

--- a/src/solutions/cmsis-toolbox.ts
+++ b/src/solutions/cmsis-toolbox.ts
@@ -92,6 +92,10 @@ export interface CmsisToolboxManager {
     * @return true if the queue is not empty or mutex is locked
     */
     isRunning(): boolean
+
+    suspendPackReload(): void
+
+    resumePackReload(): void
 }
 
 /**
@@ -124,6 +128,14 @@ export class CmsisToolboxManagerImpl implements CmsisToolboxManager {
 
     public isRunning(): boolean {
         return this.toolboxQueue.length > 0 || this.toolboxMutex.isLocked();
+    }
+
+    public suspendPackReload(): void {
+        this.csolutionService.suspendPackIdxWatcher();
+    }
+
+    public resumePackReload(): void {
+        this.csolutionService.resumePackIdxWatcher();
     }
 
     public async runCmsisTool(

--- a/src/solutions/cmsis-toolbox.ts
+++ b/src/solutions/cmsis-toolbox.ts
@@ -95,7 +95,7 @@ export interface CmsisToolboxManager {
 
     suspendPackReload(): void
 
-    resumePackReload(): void
+    resumePackReload(skipPendingReload?: boolean): void
 }
 
 /**
@@ -134,8 +134,8 @@ export class CmsisToolboxManagerImpl implements CmsisToolboxManager {
         this.csolutionService.suspendPackIdxWatcher();
     }
 
-    public resumePackReload(): void {
-        this.csolutionService.resumePackIdxWatcher();
+    public resumePackReload(skipPendingReload: boolean = false): void {
+        this.csolutionService.resumePackIdxWatcher(skipPendingReload);
     }
 
     public async runCmsisTool(

--- a/src/solutions/solution-converter.test.ts
+++ b/src/solutions/solution-converter.test.ts
@@ -266,6 +266,12 @@ describe('SolutionConverter', () => {
         expect(mockRunCmsisTool).toHaveBeenNthCalledWith(2, 'cpackget',
             expect.arrayContaining(['add', 'VendorB::PackB@2.0.0']), expect.any(Function), undefined, undefined, true);
 
+        expect(mockCsolutionService.suspendPackIdxWatcher).toHaveBeenCalledTimes(1);
+        expect(mockCsolutionService.resumePackIdxWatcher).toHaveBeenCalledTimes(1);
+        expect(mockCsolutionService.loadPacks).toHaveBeenCalledTimes(1);
+        expect(mockCsolutionService.loadPacks.mock.invocationCallOrder[0])
+            .toBeLessThan(mockCsolutionService.convertSolution.mock.invocationCallOrder[0]);
+
         expect(completedListener).toHaveBeenCalledTimes(1);
     });
 

--- a/src/solutions/solution-converter.ts
+++ b/src/solutions/solution-converter.ts
@@ -135,7 +135,8 @@ export class SolutionConverterImpl implements SolutionConverter {
                     missingPacksResult.success = downloadPacksOutput.length === 0;
                     downloadedMissingPacks = missingPacksResult.success;
                 } finally {
-                    this.cmsisToolboxManager.resumePackReload();
+                    // Converter explicitly calls LoadPacks below on successful downloads.
+                    this.cmsisToolboxManager.resumePackReload(true);
                 }
             }
         }

--- a/src/solutions/solution-converter.ts
+++ b/src/solutions/solution-converter.ts
@@ -115,6 +115,7 @@ export class SolutionConverterImpl implements SolutionConverter {
 
         outputChannel.appendLine('\n⚙️ Converting solution...');
         let missingPacksResult = undefined;
+        let downloadedMissingPacks = false;
         if (this.isDownloadPacksEnabled()) {
             // rpc method: ListMissingPacks
             outputChannel.append('Check for missing packs... ');
@@ -127,13 +128,24 @@ export class SolutionConverterImpl implements SolutionConverter {
             ) as rpc.ListMissingPacksResult;
             if (missingPacksResult.success && missingPacksResult.packs && missingPacksResult.packs.length > 0) {
                 // download missing packs if any
-                const downloadPacksOutput = await this.downloadMissingPacks(missingPacksResult.packs);
-                toolsOutputMessages = toolsOutputMessages.concat(downloadPacksOutput);
-                missingPacksResult.success = downloadPacksOutput.length === 0;
+                this.cmsisToolboxManager.suspendPackReload();
+                try {
+                    const downloadPacksOutput = await this.downloadMissingPacks(missingPacksResult.packs);
+                    toolsOutputMessages = toolsOutputMessages.concat(downloadPacksOutput);
+                    missingPacksResult.success = downloadPacksOutput.length === 0;
+                    downloadedMissingPacks = missingPacksResult.success;
+                } finally {
+                    this.cmsisToolboxManager.resumePackReload();
+                }
             }
         }
         if (signal.aborted) {
             return;
+        }
+
+        if (downloadedMissingPacks) {
+            outputChannel.append('Loading packs... ');
+            await this.cmsisToolboxManager.runCsolutionRpc('LoadPacks', {});
         }
 
         let detection = false;


### PR DESCRIPTION
## Fixes
<!-- List the GitHub issue this PR resolves -->
- #250 

## Changes
<!-- List the changes this PR introduces -->
- issue Refresh command to reload solution and perform convert after reloading packs

## Screenshots
<!-- Show UI changes with screenshots to ease UX/UI feedback: -->

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [ ] 🤖 This change is covered by unit tests (if applicable).
- [ ] 🤹 Manual testing has been performed (if necessary).
- [ ] 🛡️ Security impacts have been considered (if relevant).
- [ ] 📖 Documentation updates are complete (if required).
- [ ] 🧠 Third-party dependencies and TPIP updated (if required).
