### PR TITLE
Do not show used and latest pack info if not available

### DIFF
--- a/src/views/manage-components-packs/view/components/pack-properties.test.tsx
+++ b/src/views/manage-components-packs/view/components/pack-properties.test.tsx
@@ -336,4 +336,71 @@ describe('PackPropertiesDialog', () => {
         expect(mockOpenFile).toHaveBeenCalledWith('path/to/cbuild-pack.yml', false);
     });
 
+    it('displays packId in Used Pack when description is not "Pack not installed"', () => {
+        const pack = createMockPack({ description: 'CMSIS Pack' });
+        render(<PackPropertiesDialog pack={pack} state={{ unlilnkRequestStack: [], selectedTargetType: selectedTargetType }} allOrigins={createMockAllOrigins()} onClose={mockOnClose} />);
+
+        expect(screen.getAllByText('ARM::CMSIS@6.1.0')).toBeDefined();
+    });
+
+    it('hides packId display in Used Pack when description is "Pack not installed"', () => {
+        const pack = createMockPack({ description: 'Pack not installed' });
+        render(<PackPropertiesDialog pack={pack} state={{ unlilnkRequestStack: [], selectedTargetType: selectedTargetType }} allOrigins={createMockAllOrigins()} onClose={mockOnClose} />);
+
+        const table = screen.getByText('Used Pack:').closest('table');
+        expect(table).toBeDefined();
+        if (table) {
+            const cells = table.querySelectorAll('td');
+            const usedPackCell = Array.from(cells).find(cell => cell.textContent === 'Used Pack:');
+            if (usedPackCell) {
+                const valueCell = usedPackCell.nextElementSibling as HTMLElement;
+                expect(valueCell?.textContent).toBe('');
+            }
+        }
+    });
+
+    it('passes empty packName to PackTitleLink when description is "Pack not installed" and openFile is provided', () => {
+        const pack = createMockPack({ description: 'Pack not installed' });
+        const mockOpenFile = jest.fn();
+
+        render(
+            <PackPropertiesDialog
+                pack={pack}
+                state={{ unlilnkRequestStack: [], selectedTargetType: selectedTargetType }}
+                allOrigins={createMockAllOrigins()}
+                openFile={mockOpenFile}
+                onClose={mockOnClose}
+            />
+        );
+
+        const table = screen.getByText('Used Pack:').closest('table');
+        expect(table).toBeDefined();
+        if (table) {
+            const cells = table.querySelectorAll('td');
+            const usedPackCell = Array.from(cells).find(cell => cell.textContent === 'Used Pack:');
+            if (usedPackCell) {
+                const valueCell = usedPackCell.nextElementSibling as HTMLElement;
+                // PackTitleLink with empty packName should not display visible text
+                expect(valueCell?.textContent?.trim()).toBe('');
+            }
+        }
+    });
+
+    it('passes packId as packName to PackTitleLink when description is not "Pack not installed" and openFile is provided', () => {
+        const pack = createMockPack({ description: 'CMSIS Pack' });
+        const mockOpenFile = jest.fn();
+
+        render(
+            <PackPropertiesDialog
+                pack={pack}
+                state={{ unlilnkRequestStack: [], selectedTargetType: selectedTargetType }}
+                allOrigins={createMockAllOrigins()}
+                openFile={mockOpenFile}
+                onClose={mockOnClose}
+            />
+        );
+
+        expect(screen.getAllByText('ARM::CMSIS@6.1.0')).toBeDefined();
+    });
+
 });

--- a/src/views/manage-components-packs/view/components/pack-properties.test.tsx
+++ b/src/views/manage-components-packs/view/components/pack-properties.test.tsx
@@ -343,23 +343,14 @@ describe('PackPropertiesDialog', () => {
         expect(screen.getAllByText('ARM::CMSIS@6.1.0')).toBeDefined();
     });
 
-    it('hides packId display in Used Pack when description is "Pack not installed"', () => {
+    it('does not render Used Pack row when description is "Pack not installed"', () => {
         const pack = createMockPack({ description: 'Pack not installed' });
         render(<PackPropertiesDialog pack={pack} state={{ unlilnkRequestStack: [], selectedTargetType: selectedTargetType }} allOrigins={createMockAllOrigins()} onClose={mockOnClose} />);
 
-        const table = screen.getByText('Used Pack:').closest('table');
-        expect(table).toBeDefined();
-        if (table) {
-            const cells = table.querySelectorAll('td');
-            const usedPackCell = Array.from(cells).find(cell => cell.textContent === 'Used Pack:');
-            if (usedPackCell) {
-                const valueCell = usedPackCell.nextElementSibling as HTMLElement;
-                expect(valueCell?.textContent).toBe('');
-            }
-        }
+        expect(screen.queryByText('Used Pack:')).toBeNull();
     });
 
-    it('passes empty packName to PackTitleLink when description is "Pack not installed" and openFile is provided', () => {
+    it('does not render Used Pack row when description is "Pack not installed" and openFile is provided', () => {
         const pack = createMockPack({ description: 'Pack not installed' });
         const mockOpenFile = jest.fn();
 
@@ -373,17 +364,7 @@ describe('PackPropertiesDialog', () => {
             />
         );
 
-        const table = screen.getByText('Used Pack:').closest('table');
-        expect(table).toBeDefined();
-        if (table) {
-            const cells = table.querySelectorAll('td');
-            const usedPackCell = Array.from(cells).find(cell => cell.textContent === 'Used Pack:');
-            if (usedPackCell) {
-                const valueCell = usedPackCell.nextElementSibling as HTMLElement;
-                // PackTitleLink with empty packName should not display visible text
-                expect(valueCell?.textContent?.trim()).toBe('');
-            }
-        }
+        expect(screen.queryByText('Used Pack:')).toBeNull();
     });
 
     it('passes packId as packName to PackTitleLink when description is not "Pack not installed" and openFile is provided', () => {

--- a/src/views/manage-components-packs/view/components/pack-properties.tsx
+++ b/src/views/manage-components-packs/view/components/pack-properties.tsx
@@ -210,7 +210,12 @@ export const PackPropertiesDialog: React.FC<PackPropertiesDialogProperties> = ({
                     <Card size="small">
                         <table className='manage-component-properties-table'>
                             <tbody>
-                                <tr><td>Used Pack:</td><td>{(!firstReferencePath && openFile) ? <PackTitleLink packId={pack.packId} packName={packDisplayName} openFile={openFile} /> : packDisplayName}</td></tr>
+                                {packDisplayName ? (
+                                    <tr>
+                                        <td>Used Pack:</td>
+                                        <td>{(!firstReferencePath && openFile) ? <PackTitleLink packId={pack.packId} packName={packDisplayName} openFile={openFile} /> : packDisplayName}</td>
+                                    </tr>
+                                ) : null}
                                 <tr><td>Description:</td><td>{pack.description}</td></tr>
                                 {firstReferencePath ? <tr><td>Path:</td><td>{firstReferencePath}</td></tr> : null}
                             </tbody>

--- a/src/views/manage-components-packs/view/components/pack-properties.tsx
+++ b/src/views/manage-components-packs/view/components/pack-properties.tsx
@@ -119,7 +119,8 @@ export const PackPropertiesDialog: React.FC<PackPropertiesDialogProperties> = ({
             'Equal or higher with same major and minor version'
         ];
 
-    const latestInstalledPack = latestUpgradable ? `${pack?.name}@${latestUpgradable}` : pack?.packId;
+    const packDisplayName = pack?.description !== 'Pack not installed' ? pack?.packId : '';
+    const latestInstalledPack = latestUpgradable ? `${pack?.name}@${latestUpgradable}` : packDisplayName;
     const hasNewerOnlineVersion = !!pack?.latestOnlineVersion && !latestInstalledPack?.endsWith(pack.latestOnlineVersion);
     const onlineTooltip = hasNewerOnlineVersion ? <div>Latest version available online: {pack.latestOnlineVersion}</div> : undefined;
 
@@ -209,7 +210,7 @@ export const PackPropertiesDialog: React.FC<PackPropertiesDialogProperties> = ({
                     <Card size="small">
                         <table className='manage-component-properties-table'>
                             <tbody>
-                                <tr><td>Used Pack:</td><td>{(!firstReferencePath && openFile) ? <PackTitleLink packId={pack.packId} packName={pack.packId} openFile={openFile} /> : pack.packId}</td></tr>
+                                <tr><td>Used Pack:</td><td>{(!firstReferencePath && openFile) ? <PackTitleLink packId={pack.packId} packName={packDisplayName} openFile={openFile} /> : packDisplayName}</td></tr>
                                 <tr><td>Description:</td><td>{pack.description}</td></tr>
                                 {firstReferencePath ? <tr><td>Path:</td><td>{firstReferencePath}</td></tr> : null}
                             </tbody>
@@ -224,7 +225,7 @@ export const PackPropertiesDialog: React.FC<PackPropertiesDialogProperties> = ({
                                     <Tooltip title={<span>Update and remove lock in <a onClick={() => { if (openFile && cbuildPackPath) openFile(cbuildPackPath, false); }}><EditFilled /></a>{cbuildPackPath} {unlockOf && <><br />Pending unlock request will be committed on save</>}</span>}>
                                         <Button
                                             type="text"
-                                            disabled={latestInstalledPack === pack.packId || unlockOf === pack.name}
+                                            disabled={!latestInstalledPack || latestInstalledPack === pack.packId || unlockOf === pack.name}
                                             style={{ border: unlockOf ? '1px dashed var(--vscode-foreground)' : 'none' }}
                                             onClick={requestUnlock}
                                             icon={<CmsisCodicon name="update-arrow" />}


### PR DESCRIPTION
## Fixes
<!-- List the GitHub issue this PR resolves -->
- #255

## Changes
<!-- List the changes this PR introduces -->
- Do not show used pack if pack is not installed (not available)
- do not show latest installed pack if no pack installed 

## Screenshots
<!-- Show UI changes with screenshots to ease UX/UI feedback: -->
<img width="1820" height="1527" alt="image" src="https://github.com/user-attachments/assets/7debfa33-cbca-4e8f-8550-07c8796af471" />

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [ ] 🤖 This change is covered by unit tests (if applicable).
- [ ] 🤹 Manual testing has been performed (if necessary).
- [ ] 🛡️ Security impacts have been considered (if relevant).
- [ ] 📖 Documentation updates are complete (if required).
- [ ] 🧠 Third-party dependencies and TPIP updated (if required).
