### PR TITLE
Rework setup and build phases concurrency handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -975,7 +975,7 @@
       "view/title": [
         {
           "command": "cmsis-csolution.build",
-          "when": "view == cmsis-csolution.outline && cmsis-csolution.activeSolutionState == active && cmsis-csolution.buildState == idle",
+          "when": "view == cmsis-csolution.outline && cmsis-csolution.activeSolutionState == active && (cmsis-csolution.buildState == idle || cmsis-csolution.buildState == setup)",
           "group": "navigation@1"
         },
         {

--- a/src/desktop/extension.ts
+++ b/src/desktop/extension.ts
@@ -172,7 +172,7 @@ export const activate = async (context: ExtensionContext): Promise<CsolutionExte
 
     const buildTaskProvider = new BuildTaskProviderImpl(buildRunner);
     const buildTaskDefinitionBuilder = new BuildTaskDefinitionBuilderImpl(solutionManager, configurationProvider);
-    const compileCommandsGenerator = new CompileCommandsGenerator(buildTaskProvider, buildTaskDefinitionBuilder, eventHub, outputChannelProvider);
+    const compileCommandsGenerator = new CompileCommandsGenerator(buildTaskProvider, buildTaskDefinitionBuilder, eventHub, outputChannelProvider, commandsProvider);
 
     const solutionConverterImpl = new SolutionConverterImpl(
         eventHub,

--- a/src/solutions/cmsis-toolbox.factories.ts
+++ b/src/solutions/cmsis-toolbox.factories.ts
@@ -21,11 +21,11 @@ export type MockCmsisToolboxManager =
     jest.Mocked<Omit<CmsisToolboxManager, 'onRunCmsisTool'>> &
     {
         onRunCmsisTool: CmsisToolboxManager['onRunCmsisTool']
-        mockTriggerOnRunCmsisTool: (start: boolean, packs: boolean) => void
+        mockTriggerOnRunCmsisTool: (start: boolean, packs?: boolean, cbuildSetup?: boolean) => void
     }
 
 export const cmsisToolboxManagerFactory = (): MockCmsisToolboxManager => {
-    const onRunCmsisToolEventEmitter = new vscode.EventEmitter<[boolean, boolean?]>();
+    const onRunCmsisToolEventEmitter = new vscode.EventEmitter<[boolean, boolean?, boolean?]>();
     return {
         runCmsisTool: jest.fn().mockResolvedValue([0, undefined]),
         runCsolutionRpc: jest.fn().mockResolvedValue({ success: true }),
@@ -35,8 +35,8 @@ export const cmsisToolboxManagerFactory = (): MockCmsisToolboxManager => {
         collectSetupMessages: jest.fn(),
         getSetupMessages: jest.fn(),
         onRunCmsisTool: onRunCmsisToolEventEmitter.event,
-        mockTriggerOnRunCmsisTool: (start: boolean, packs: boolean) => {
-            onRunCmsisToolEventEmitter.fire([start, packs]);
+        mockTriggerOnRunCmsisTool: (start: boolean, packs?: boolean, cbuildSetup?: boolean) => {
+            onRunCmsisToolEventEmitter.fire([start, packs, cbuildSetup]);
         },
         activate: jest.fn(),
     };

--- a/src/solutions/cmsis-toolbox.ts
+++ b/src/solutions/cmsis-toolbox.ts
@@ -45,7 +45,7 @@ const isErrnoException = (e: unknown): e is NodeJS.ErrnoException => Boolean(e) 
 export interface CmsisToolboxManager {
     activate(context: vscode.ExtensionContext): Promise<void>
 
-    readonly onRunCmsisTool: vscode.Event<[boolean, boolean?]>;
+    readonly onRunCmsisTool: vscode.Event<[boolean, boolean?, boolean?]>;
 
     /** Run CMSIS Tool
     * @param tool name of CMSIS command line tool to be executed
@@ -112,7 +112,7 @@ export class CmsisToolboxManagerImpl implements CmsisToolboxManager {
     ) {
     }
 
-    private readonly runCmsisToolEmitter = new vscode.EventEmitter<[boolean, boolean?]>();
+    private readonly runCmsisToolEmitter = new vscode.EventEmitter<[boolean, boolean?, boolean?]>();
     public readonly onRunCmsisTool = this.runCmsisToolEmitter.event;
 
     private readonly toolboxMutex = new Mutex();
@@ -196,11 +196,11 @@ export class CmsisToolboxManagerImpl implements CmsisToolboxManager {
         if (tool === 'cbuild') {
             if (args.includes('setup')) {
                 // notify cbuild setup is started but do not notify other cbuild calls (e.g. during build)
-                this.runCmsisToolEmitter.fire([true, false]);
+                this.runCmsisToolEmitter.fire([true, false, true]);
             }
         } else {
             // set 'packs' event flag when installing packs via 'cpackget add' command
-            this.runCmsisToolEmitter.fire([true, tool === 'cpackget' && args.includes('add')]);
+            this.runCmsisToolEmitter.fire([true, tool === 'cpackget' && args.includes('add'), false]);
         }
 
         const [cmdMsg, returnCode] = await this.runCmd(

--- a/src/solutions/cmsis-toolbox.ts
+++ b/src/solutions/cmsis-toolbox.ts
@@ -193,7 +193,12 @@ export class CmsisToolboxManagerImpl implements CmsisToolboxManager {
             onOutput(msg);
         }
 
-        if (tool !== 'cbuild') { // do not notify cbuild is started
+        if (tool === 'cbuild') {
+            if (args.includes('setup')) {
+                // notify cbuild setup is started but do not notify other cbuild calls (e.g. during build)
+                this.runCmsisToolEmitter.fire([true, false]);
+            }
+        } else {
             // set 'packs' event flag when installing packs via 'cpackget add' command
             this.runCmsisToolEmitter.fire([true, tool === 'cpackget' && args.includes('add')]);
         }

--- a/src/solutions/intellisense/compile-commands-generator.test.ts
+++ b/src/solutions/intellisense/compile-commands-generator.test.ts
@@ -25,6 +25,7 @@ import { SolutionEventHub } from '../solution-event-hub';
 import * as manifest from '../../manifest';
 import { MockOutputChannelProvider, outputChannelProviderFactory } from '../../vscode-api/output-channel-provider.factories';
 import { waitTimeout } from '../../__test__/test-waits';
+import { commandsProviderFactory, MockCommandsProvider } from '../../vscode-api/commands-provider.factories';
 
 jest.mock('which', () => jest.fn((cmd) => Promise.resolve(path.join('path', 'to', cmd))));
 
@@ -36,10 +37,18 @@ describe('CompileCommandsGenerator', () => {
     let exitCode: number;
     let mockEventHub: jest.Mocked<SolutionEventHub>;
     let outputChannelProvider: MockOutputChannelProvider;
+    let commandsProvider: MockCommandsProvider;
     let cbuildSetupRequestedListener: (() => void) | undefined;
 
     beforeEach(async () => {
         exitCode = 0;
+        (vscode.tasks as unknown as {
+            taskExecutions: vscode.TaskExecution[];
+            onDidEndTask: (listener: (event: vscode.TaskEndEvent) => void) => vscode.Disposable;
+        }).taskExecutions = [];
+        (vscode.tasks as unknown as {
+            onDidEndTask: (listener: (event: vscode.TaskEndEvent) => void) => vscode.Disposable;
+        }).onDidEndTask = () => ({ dispose: jest.fn() } as unknown as vscode.Disposable);
         mockEventHub = {
             fireCbuildCompleted: jest.fn().mockResolvedValue(undefined),
             onDidCbuildSetupRequested: jest.fn((listener: () => void) => {
@@ -48,6 +57,8 @@ describe('CompileCommandsGenerator', () => {
             }),
         } as unknown as jest.Mocked<SolutionEventHub>;
         outputChannelProvider = outputChannelProviderFactory();
+        commandsProvider = commandsProviderFactory();
+        commandsProvider.executeCommand.mockResolvedValue(undefined);
 
         const buildTaskDefinition: BuildTaskDefinition = {
             type: BuildTaskProviderImpl.taskType,
@@ -79,6 +90,7 @@ describe('CompileCommandsGenerator', () => {
             buildTaskDefinitionBuilder,
             mockEventHub,
             outputChannelProvider,
+            commandsProvider,
         );
         generator.activate({ subscriptions: [] } as unknown as vscode.ExtensionContext);
 
@@ -93,6 +105,7 @@ describe('CompileCommandsGenerator', () => {
         await waitTimeout();
 
         const outputChannel = outputChannelProvider.mockGetCreatedChannelByName(manifest.CMSIS_SOLUTION_OUTPUT_CHANNEL);
+        expect(commandsProvider.executeCommand).toHaveBeenCalledWith('workbench.action.files.save');
         expect(vscode.tasks.executeTask).toHaveBeenCalledTimes(1);
         expect(outputChannel!.appendLine).toHaveBeenCalledWith('Launching cbuild setup in Terminal to generate IntelliSense database');
         expect(mockEventHub.fireCbuildCompleted).toHaveBeenCalledWith({ success: true, severity: 'success', toolsOutputMessages: ['completed with exit code 0'] });
@@ -106,7 +119,55 @@ describe('CompileCommandsGenerator', () => {
         cbuildSetupRequestedListener?.();
         await waitTimeout();
 
+        const saveCommandCallOrder = commandsProvider.executeCommand.mock.invocationCallOrder[0];
+        const createDefinitionCallOrder = buildTaskDefinitionBuilder.createDefinitionFromUriOrSolutionNode.mock.invocationCallOrder[0];
+
+        expect(commandsProvider.executeCommand).toHaveBeenCalledWith('workbench.action.files.save');
+        expect(saveCommandCallOrder).toBeLessThan(createDefinitionCallOrder);
         expect(vscode.tasks.executeTask).toHaveBeenCalledTimes(1);
+    });
+
+    it('coalesces concurrent cbuild setup requests into one run', async () => {
+        (mockBuildTaskProvider.getActiveTaskRunner as jest.Mock).mockReturnValue({
+            getOutputBuffer: () => ['completed with exit code 0']
+        });
+
+        cbuildSetupRequestedListener?.();
+        cbuildSetupRequestedListener?.();
+        await waitTimeout();
+
+        expect(vscode.tasks.executeTask).toHaveBeenCalledTimes(1);
+        expect(mockEventHub.fireCbuildCompleted).toHaveBeenCalledTimes(1);
+    });
+
+    it('waits for active build task completion before creating setup task', async () => {
+        const activeExecution = {
+            task: {
+                definition: { type: BuildTaskProviderImpl.taskType }
+            }
+        } as unknown as vscode.TaskExecution;
+        const onDidEndTaskCallbacks: Array<(event: vscode.TaskEndEvent) => void> = [];
+
+        (vscode.tasks as unknown as {
+            taskExecutions: vscode.TaskExecution[];
+            onDidEndTask: (listener: (event: vscode.TaskEndEvent) => void) => vscode.Disposable;
+        }).taskExecutions = [activeExecution];
+        (vscode.tasks as unknown as {
+            onDidEndTask: (listener: (event: vscode.TaskEndEvent) => void) => vscode.Disposable;
+        }).onDidEndTask = (listener) => {
+            onDidEndTaskCallbacks.push(listener);
+            return { dispose: jest.fn() } as unknown as vscode.Disposable;
+        };
+
+        cbuildSetupRequestedListener?.();
+        await Promise.resolve();
+
+        expect(mockBuildTaskProvider.createTask).not.toHaveBeenCalled();
+
+        onDidEndTaskCallbacks[0]({ execution: activeExecution } as vscode.TaskEndEvent);
+        await waitTimeout();
+
+        expect(mockBuildTaskProvider.createTask).toHaveBeenCalledTimes(1);
     });
 
     it('prints an error message if the compilation database could not be generated', async () => {

--- a/src/solutions/intellisense/compile-commands-generator.test.ts
+++ b/src/solutions/intellisense/compile-commands-generator.test.ts
@@ -42,6 +42,11 @@ describe('CompileCommandsGenerator', () => {
 
     beforeEach(async () => {
         exitCode = 0;
+        (vscode.window as unknown as {
+            activeTextEditor: { document: { isDirty: boolean } } | undefined;
+        }).activeTextEditor = {
+            document: { isDirty: true }
+        };
         (vscode.tasks as unknown as {
             taskExecutions: vscode.TaskExecution[];
             onDidEndTask: (listener: (event: vscode.TaskEndEvent) => void) => vscode.Disposable;
@@ -124,6 +129,24 @@ describe('CompileCommandsGenerator', () => {
 
         expect(commandsProvider.executeCommand).toHaveBeenCalledWith('workbench.action.files.save');
         expect(saveCommandCallOrder).toBeLessThan(createDefinitionCallOrder);
+        expect(vscode.tasks.executeTask).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not save files when active editor is not dirty', async () => {
+        (vscode.window as unknown as {
+            activeTextEditor: { document: { isDirty: boolean } } | undefined;
+        }).activeTextEditor = {
+            document: { isDirty: false }
+        };
+        (mockBuildTaskProvider.getActiveTaskRunner as jest.Mock).mockReturnValue({
+            getOutputBuffer: () => ['completed with exit code 0']
+        });
+
+        cbuildSetupRequestedListener?.();
+        await waitTimeout();
+
+        expect(commandsProvider.executeCommand).not.toHaveBeenCalledWith('workbench.action.files.save');
+        expect(buildTaskDefinitionBuilder.createDefinitionFromUriOrSolutionNode).toHaveBeenCalledWith('setup');
         expect(vscode.tasks.executeTask).toHaveBeenCalledTimes(1);
     });
 

--- a/src/solutions/intellisense/compile-commands-generator.test.ts
+++ b/src/solutions/intellisense/compile-commands-generator.test.ts
@@ -194,6 +194,38 @@ describe('CompileCommandsGenerator', () => {
         });
     });
 
+    it('reports error with incomplete setup message when task is aborted', async () => {
+        (mockBuildTaskProvider.getActiveTaskRunner as jest.Mock).mockReturnValue({
+            getOutputBuffer: () => []
+        });
+        exitCode = -1;
+        cbuildSetupRequestedListener?.();
+        await waitTimeout();
+
+        expect(mockEventHub.fireCbuildCompleted).toHaveBeenCalledWith(
+            expect.objectContaining({
+                success: false,
+                severity: 'error',
+                toolsOutputMessages: expect.arrayContaining([expect.stringContaining('cbuild setup incomplete, use Refresh command')])
+            })
+        );
+    });
+
+    it('does not append incomplete setup message when exit code is -1 but tool output already contains an error', async () => {
+        (mockBuildTaskProvider.getActiveTaskRunner as jest.Mock).mockReturnValue({
+            getOutputBuffer: () => ['error cbuild: failed to generate']
+        });
+        exitCode = -1;
+        cbuildSetupRequestedListener?.();
+        await waitTimeout();
+
+        expect(mockEventHub.fireCbuildCompleted).toHaveBeenCalledWith({
+            success: false,
+            severity: 'error',
+            toolsOutputMessages: ['error cbuild: failed to generate']
+        });
+    });
+
     it('reports error severity when exit code is 0 but output contains error pattern', async () => {
         (mockBuildTaskProvider.getActiveTaskRunner as jest.Mock).mockReturnValue({
             getOutputBuffer: () => ['error cbuild: failed to generate', 'completed with exit code 0']

--- a/src/solutions/intellisense/compile-commands-generator.ts
+++ b/src/solutions/intellisense/compile-commands-generator.ts
@@ -18,17 +18,21 @@ import * as vscode from 'vscode';
 import { ExtensionContext } from 'vscode';
 import * as manifest from '../../manifest';
 import { BuildTaskDefinitionBuilder } from '../../tasks/build/build-task-definition-builder';
-import { BuildTaskProvider } from '../../tasks/build/build-task-provider';
+import { BuildTaskProvider, waitForActiveBuildTasksCompletion } from '../../tasks/build/build-task-provider';
 import { SolutionEventHub } from '../solution-event-hub';
 import { getToolsSeverity } from '../solution-problems';
 import { OutputChannelProvider } from '../../vscode-api/output-channel-provider';
+import { CommandsProvider } from '../../vscode-api/commands-provider';
 
 export class CompileCommandsGenerator {
+    private runningSetupRequest: Promise<void> | undefined;
+
     constructor(
         private readonly buildTaskProvider: BuildTaskProvider,
         private readonly buildTaskDefinitionBuilder: BuildTaskDefinitionBuilder,
         private readonly eventHub: SolutionEventHub,
         private readonly outputChannelProvider: OutputChannelProvider,
+        private readonly commandsProvider: CommandsProvider,
     ) {
     }
 
@@ -36,16 +40,35 @@ export class CompileCommandsGenerator {
         context.subscriptions.push(
             this.eventHub.onDidCbuildSetupRequested(() => {
                 // fire-and-forget: completion is reported via onDidCbuildCompleted
-                void this.runCbuildSetup();
+                void this.runCbuildSetupOnce();
             }),
         );
     }
 
     private readonly outputRegex = /\b(?:completed|failed)\s+with\s+exit\s+code\s*([+-]?\d+)\b/i;
 
-    private async runCbuildSetup(): Promise<void> {
+    private async prepareSetupTask() {
+        await waitForActiveBuildTasksCompletion();
+        await this.commandsProvider.executeCommand('workbench.action.files.save');
         const definition = await this.buildTaskDefinitionBuilder.createDefinitionFromUriOrSolutionNode('setup');
-        const task = this.buildTaskProvider.createTask(definition);
+        return this.buildTaskProvider.createTask(definition);
+    }
+
+    private runCbuildSetupOnce(): Promise<void> {
+        if (this.runningSetupRequest) {
+            return this.runningSetupRequest;
+        }
+
+        this.runningSetupRequest = this.runCbuildSetup().finally(() => {
+            this.runningSetupRequest = undefined;
+        });
+
+        return this.runningSetupRequest;
+    }
+
+    private async runCbuildSetup(): Promise<void> {
+        const task = await this.prepareSetupTask();
+        const definition = task.definition;
         const revealKind = definition.west ? vscode.TaskRevealKind?.Always : vscode.TaskRevealKind?.Silent;
         task.presentationOptions = {
             ...(revealKind !== undefined ? { reveal: revealKind } : {})

--- a/src/solutions/intellisense/compile-commands-generator.ts
+++ b/src/solutions/intellisense/compile-commands-generator.ts
@@ -49,7 +49,9 @@ export class CompileCommandsGenerator {
 
     private async prepareSetupTask() {
         await waitForActiveBuildTasksCompletion();
-        await this.commandsProvider.executeCommand('workbench.action.files.save');
+        if (vscode.window.activeTextEditor?.document.isDirty) {
+            await this.commandsProvider.executeCommand('workbench.action.files.save');
+        }
         const definition = await this.buildTaskDefinitionBuilder.createDefinitionFromUriOrSolutionNode('setup');
         return this.buildTaskProvider.createTask(definition);
     }

--- a/src/solutions/intellisense/compile-commands-generator.ts
+++ b/src/solutions/intellisense/compile-commands-generator.ts
@@ -86,9 +86,17 @@ export class CompileCommandsGenerator {
                     const match = this.outputRegex.exec(output.join('\n'));
                     const returnCode = match?.[1] !== undefined ? Number(match[1]) :
                         event.exitCode !== undefined ? event.exitCode : -1;
+
+                    const outputSeverity = getToolsSeverity(output);
+                    // Detect task abort (exit code -1 without tool-reported error indicates user termination)
+                    const isAborted = returnCode === -1 && outputSeverity !== 'error';
+                    if (isAborted) {
+                        output.push('error cbuild: cbuild setup incomplete, use Refresh command');
+                    }
+
                     const success = returnCode === 0;
-                    const severity = success ? getToolsSeverity(output) : 'error';
-                    this.eventHub.fireCbuildCompleted({ success, severity, toolsOutputMessages: output });
+                    const severity = isAborted ? 'error' : (success ? outputSeverity : 'error');
+                    this.eventHub.fireCbuildCompleted({ success: isAborted ? false : success, severity, toolsOutputMessages: output });
                     resolve();
                 }
             });

--- a/src/status-bar.test.ts
+++ b/src/status-bar.test.ts
@@ -107,15 +107,20 @@ describe('StatusBar', () => {
             expect(statusBarItem.show).toHaveBeenCalledTimes(3);
             expect(statusBarItem.text).toBe('$(sync~spin) target@set');
 
+            // start cbuild setup
+            cmsisToolboxManager.mockTriggerOnRunCmsisTool(true, false, true);
+            expect(statusBarItem.show).toHaveBeenCalledTimes(4);
+            expect(statusBarItem.text).toBe('$(sync~spin) Building Compilation Database...');
+
             // end cmsis tool
             cmsisToolboxManager.mockTriggerOnRunCmsisTool(false, false);
-            expect(statusBarItem.show).toHaveBeenCalledTimes(4);
+            expect(statusBarItem.show).toHaveBeenCalledTimes(5);
             expect(statusBarItem.text).toBe('$(target) target@set');
             expect(statusBarItem.tooltip.valueOf()).toEqual('**solution/test**\n - project.build\n');
 
             // cbuild setup completed and files loaded successfully
             solutionManager.onDidSetupCompletedEmitter.fire(['success', false]);
-            expect(statusBarItem.show).toHaveBeenCalledTimes(5);
+            expect(statusBarItem.show).toHaveBeenCalledTimes(6);
             expect(statusBarItem.backgroundColor).toStrictEqual(themeProvider.getThemeColor('statusBarItem.background'));
 
             // Run status bar command
@@ -126,7 +131,7 @@ describe('StatusBar', () => {
 
             // cbuild setup completed with error
             solutionManager.onDidSetupCompletedEmitter.fire(['error', false]);
-            expect(statusBarItem.show).toHaveBeenCalledTimes(6);
+            expect(statusBarItem.show).toHaveBeenCalledTimes(7);
             expect(statusBarItem.backgroundColor).toStrictEqual(themeProvider.getThemeColor('statusBarItem.errorBackground'));
 
             // Run status bar command

--- a/src/status-bar.test.ts
+++ b/src/status-bar.test.ts
@@ -55,9 +55,10 @@ describe('StatusBar', () => {
 
             await statusBar.activate(extensionContext);
 
-            expect(mockCreateStatusBarItem).toHaveBeenCalledTimes(1);
+            expect(mockCreateStatusBarItem).toHaveBeenCalledTimes(2);
             expect(mockCreateStatusBarItem.mock.results[0].value.command).toBe(StatusBar.commandType);
             expect(mockCreateStatusBarItem.mock.results[0].value.name).toBe('CMSIS Context');
+            expect(mockCreateStatusBarItem.mock.results[1].value.name).toBe('CMSIS Setup');
         });
 
         it('shows and hides the status bar item according to load state', async () => {
@@ -96,6 +97,7 @@ describe('StatusBar', () => {
             const statusBar = new StatusBar(solutionManager, cmsisToolboxManager, themeProvider);
             await statusBar.activate(extensionContext);
             const statusBarItem = mockCreateStatusBarItem.mock.results[0].value;
+            const operationStatusBarItem = mockCreateStatusBarItem.mock.results[1].value;
 
             // start cmsis tool
             solutionManager.fireOnDidChangeLoadState(
@@ -109,18 +111,20 @@ describe('StatusBar', () => {
 
             // start cbuild setup
             cmsisToolboxManager.mockTriggerOnRunCmsisTool(true, false, true);
-            expect(statusBarItem.show).toHaveBeenCalledTimes(4);
-            expect(statusBarItem.text).toBe('$(sync~spin) Building Compilation Database...');
+            expect(operationStatusBarItem.show).toHaveBeenCalledTimes(1);
+            expect(operationStatusBarItem.text).toBe('$(sync~spin) Building Compilation Database...');
 
             // end cmsis tool
             cmsisToolboxManager.mockTriggerOnRunCmsisTool(false, false);
-            expect(statusBarItem.show).toHaveBeenCalledTimes(5);
+            expect(operationStatusBarItem.hide).toHaveBeenCalledTimes(3);
+            expect(statusBarItem.show).toHaveBeenCalledTimes(4);
             expect(statusBarItem.text).toBe('$(target) target@set');
             expect(statusBarItem.tooltip.valueOf()).toEqual('**solution/test**\n - project.build\n');
 
             // cbuild setup completed and files loaded successfully
             solutionManager.onDidSetupCompletedEmitter.fire(['success', false]);
-            expect(statusBarItem.show).toHaveBeenCalledTimes(6);
+            expect(operationStatusBarItem.hide).toHaveBeenCalledTimes(4);
+            expect(statusBarItem.show).toHaveBeenCalledTimes(5);
             expect(statusBarItem.backgroundColor).toStrictEqual(themeProvider.getThemeColor('statusBarItem.background'));
 
             // Run status bar command
@@ -131,7 +135,8 @@ describe('StatusBar', () => {
 
             // cbuild setup completed with error
             solutionManager.onDidSetupCompletedEmitter.fire(['error', false]);
-            expect(statusBarItem.show).toHaveBeenCalledTimes(7);
+            expect(operationStatusBarItem.hide).toHaveBeenCalledTimes(5);
+            expect(statusBarItem.show).toHaveBeenCalledTimes(6);
             expect(statusBarItem.backgroundColor).toStrictEqual(themeProvider.getThemeColor('statusBarItem.errorBackground'));
 
             // Run status bar command

--- a/src/status-bar.ts
+++ b/src/status-bar.ts
@@ -36,6 +36,7 @@ export class StatusBar {
     public static readonly commandType = `${manifest.PACKAGE_NAME}.showContextSelection`;
     private statusBarItemIcon = '$(target)';
     private cbuildSetupStatus = ECbuildSetupStatus.Idle;
+    private operationStatusBarItem: vscode.StatusBarItem | undefined;
 
     public constructor(
         protected readonly solutionManager: SolutionManager,
@@ -49,12 +50,17 @@ export class StatusBar {
         statusBarItem.command = StatusBar.commandType;
         statusBarItem.text = '$(sync~spin) Loading Solution...';
 
+        // Create separate status bar item on the right for cbuild setup indication
+        this.operationStatusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left);
+        this.operationStatusBarItem.name = 'CMSIS Setup';
+
         context.subscriptions.push(
             vscode.commands.registerCommand(StatusBar.commandType, () => this.runOnClick()),
             this.cmsisToolboxManager.onRunCmsisTool(([start, packs, cbuildSetup]) => this.updateIconStatus(statusBarItem, start, packs, cbuildSetup)),
             this.solutionManager.onDidSetupCompleted(([severity, detection]) => this.updateCbuildSetupStatus(statusBarItem, severity, detection)),
             this.solutionManager.onDidChangeLoadState((event) => this.handleLoadStateChange(statusBarItem, event)),
             statusBarItem,
+            this.operationStatusBarItem,
         );
     }
 
@@ -123,12 +129,13 @@ export class StatusBar {
         // Animation from: https://code.visualstudio.com/api/references/icons-in-labels
         this.statusBarItemIcon = start ? '$(sync~spin)' : '$(target)';
         if (cbuildSetup) {
-            statusBarItem.text = `${this.statusBarItemIcon} Building Compilation Database...`;
-            statusBarItem.show();
+            this.operationStatusBarItem!.text = `${this.statusBarItemIcon} Building Compilation Database...`;
+            this.operationStatusBarItem!.show();
         } else if (packs) {
             statusBarItem.text = `${this.statusBarItemIcon} Downloading Packs...`;
             statusBarItem.show();
         } else {
+            this.operationStatusBarItem!.hide();
             this.updateContext(statusBarItem);
         }
     }
@@ -141,6 +148,8 @@ export class StatusBar {
 
     protected updateCbuildSetupStatus(statusBarItem: vscode.StatusBarItem, severity: Severity, detection: boolean) {
         this.retrieveCbuildSetupStatus(severity, detection);
+        // Hide the setup operation status item when setup completes
+        this.operationStatusBarItem!.hide();
         // Color references from: https://code.visualstudio.com/api/references/theme-color#status-bar-colors
         const color = this.cbuildSetupStatus === ECbuildSetupStatus.Error ? 'statusBarItem.errorBackground' :
             this.cbuildSetupStatus === ECbuildSetupStatus.Warning ? 'statusBarItem.warningBackground' : 'statusBarItem.background';

--- a/src/status-bar.ts
+++ b/src/status-bar.ts
@@ -51,7 +51,7 @@ export class StatusBar {
 
         context.subscriptions.push(
             vscode.commands.registerCommand(StatusBar.commandType, () => this.runOnClick()),
-            this.cmsisToolboxManager.onRunCmsisTool(([start, packs]) => this.updateIconStatus(statusBarItem, start, packs)),
+            this.cmsisToolboxManager.onRunCmsisTool(([start, packs, cbuildSetup]) => this.updateIconStatus(statusBarItem, start, packs, cbuildSetup)),
             this.solutionManager.onDidSetupCompleted(([severity, detection]) => this.updateCbuildSetupStatus(statusBarItem, severity, detection)),
             this.solutionManager.onDidChangeLoadState((event) => this.handleLoadStateChange(statusBarItem, event)),
             statusBarItem,
@@ -119,10 +119,13 @@ export class StatusBar {
         return ` - ${context.projectName}${build}\n`;
     }
 
-    protected updateIconStatus(statusBarItem: vscode.StatusBarItem, start: boolean, packs?: boolean): void {
+    protected updateIconStatus(statusBarItem: vscode.StatusBarItem, start: boolean, packs?: boolean, cbuildSetup?: boolean): void {
         // Animation from: https://code.visualstudio.com/api/references/icons-in-labels
         this.statusBarItemIcon = start ? '$(sync~spin)' : '$(target)';
-        if (packs) {
+        if (cbuildSetup) {
+            statusBarItem.text = `${this.statusBarItemIcon} Building Compilation Database...`;
+            statusBarItem.show();
+        } else if (packs) {
             statusBarItem.text = `${this.statusBarItemIcon} Downloading Packs...`;
             statusBarItem.show();
         } else {

--- a/src/tasks/build/build-command.test.ts
+++ b/src/tasks/build/build-command.test.ts
@@ -37,6 +37,13 @@ describe('BuildCommand', () => {
 
     beforeEach(async () => {
         commandsProvider = commandsProviderFactory();
+        (vscode.tasks as unknown as {
+            taskExecutions: vscode.TaskExecution[];
+            onDidEndTask: (listener: (event: vscode.TaskEndEvent) => void) => vscode.Disposable;
+        }).taskExecutions = [];
+        (vscode.tasks as unknown as {
+            onDidEndTask: (listener: (event: vscode.TaskEndEvent) => void) => vscode.Disposable;
+        }).onDidEndTask = () => ({ dispose: jest.fn() } as unknown as vscode.Disposable);
         mockBuildTaskProvider = {
             createTask: jest.fn((taskDefinition) => new vscode.Task(
                 taskDefinition, vscode.TaskScope.Workspace, 'cbuild some-solution-path', taskDefinition.type
@@ -46,6 +53,7 @@ describe('BuildCommand', () => {
         };
         buildTaskDefinitionBuilder = buildTaskDefinitionBuilderFactory();
         buildTaskDefinitionBuilder.createDefinitionFromUriOrSolutionNode.mockResolvedValue(buildTaskDefinition);
+        commandsProvider.executeCommand.mockResolvedValue(undefined);
     });
 
     it('registers the build, clean and rebuild commands on activation', async () => {
@@ -74,7 +82,13 @@ describe('BuildCommand', () => {
 
             await commandsProvider.mockRunRegistered(BuildCommand.buildCommandType, undefined);
 
+            expect(commandsProvider.executeCommand).toHaveBeenCalledWith('workbench.action.files.save');
             expect(buildTaskDefinitionBuilder.createDefinitionFromUriOrSolutionNode).toHaveBeenCalledWith('build', undefined);
+
+            const saveCommandCallOrder = commandsProvider.executeCommand.mock.invocationCallOrder[0];
+            const createDefinitionCallOrder = buildTaskDefinitionBuilder.createDefinitionFromUriOrSolutionNode.mock.invocationCallOrder[0];
+            expect(saveCommandCallOrder).toBeLessThan(createDefinitionCallOrder);
+
             expect(mockExecuteTask).toHaveBeenCalledTimes(1);
             expect(mockExecuteTask).toHaveBeenCalledWith({
                 definition: buildTaskDefinition,
@@ -98,6 +112,7 @@ describe('BuildCommand', () => {
 
             await commandsProvider.mockRunRegistered(BuildCommand.rebuildCommandType);
 
+            expect(commandsProvider.executeCommand).toHaveBeenCalledWith('workbench.action.files.save');
             expect(buildTaskDefinitionBuilder.createDefinitionFromUriOrSolutionNode).toHaveBeenCalledWith('rebuild', undefined);
             expect(mockExecuteTask).toHaveBeenCalledTimes(1);
             expect(mockExecuteTask).toHaveBeenCalledWith({
@@ -121,6 +136,7 @@ describe('BuildCommand', () => {
 
             await commandsProvider.mockRunRegistered(BuildCommand.cleanCommandType);
 
+            expect(commandsProvider.executeCommand).toHaveBeenCalledWith('workbench.action.files.save');
             expect(buildTaskDefinitionBuilder.createDefinitionFromUriOrSolutionNode).toHaveBeenCalledWith('clean', undefined);
             expect(mockExecuteTask).toHaveBeenCalledTimes(1);
             expect(mockExecuteTask).toHaveBeenCalledWith({

--- a/src/tasks/build/build-command.ts
+++ b/src/tasks/build/build-command.ts
@@ -18,7 +18,7 @@ import * as vscode from 'vscode';
 import { PACKAGE_NAME } from '../../manifest';
 import { CommandsProvider } from '../../vscode-api/commands-provider';
 import { BuildTaskDefinition } from './build-task-definition';
-import { BuildTaskProvider } from './build-task-provider';
+import { BuildTaskProvider, waitForActiveBuildTasksCompletion } from './build-task-provider';
 import { BuildTaskDefinitionBuilder } from './build-task-definition-builder';
 import { COutlineItem } from '../../views/solution-outline/tree-structure/solution-outline-item';
 
@@ -44,18 +44,26 @@ export class BuildCommand {
     }
 
     private async handleBuild(uriOrSolutionNode?: UriOrSolutionNode): Promise<vscode.TaskExecution | undefined> {
-        const definition = await this.buildTaskDefinitionBuilder.createDefinitionFromUriOrSolutionNode('build', uriOrSolutionNode);
-        return this.executeTaskDefinition(definition);
+        return this.createAndExecuteTaskDefinition('build', uriOrSolutionNode);
     }
 
     private async handleClean(uriOrSolutionNode?: UriOrSolutionNode): Promise<vscode.TaskExecution> {
-        const definition = await this.buildTaskDefinitionBuilder.createDefinitionFromUriOrSolutionNode('clean', uriOrSolutionNode);
-        return this.executeTaskDefinition(definition);
+        return this.createAndExecuteTaskDefinition('clean', uriOrSolutionNode);
     }
 
     private async handleRebuild(uriOrSolutionNode?: UriOrSolutionNode): Promise<vscode.TaskExecution> {
-        const definition = await this.buildTaskDefinitionBuilder.createDefinitionFromUriOrSolutionNode('rebuild', uriOrSolutionNode);
+        return this.createAndExecuteTaskDefinition('rebuild', uriOrSolutionNode);
+    }
+
+    private async createAndExecuteTaskDefinition(action: 'build' | 'clean' | 'rebuild', uriOrSolutionNode?: UriOrSolutionNode): Promise<vscode.TaskExecution> {
+        await waitForActiveBuildTasksCompletion();
+        await this.saveDirtyManageSolutionTarget();
+        const definition = await this.buildTaskDefinitionBuilder.createDefinitionFromUriOrSolutionNode(action, uriOrSolutionNode);
         return this.executeTaskDefinition(definition);
+    }
+
+    private async saveDirtyManageSolutionTarget(): Promise<void> {
+        await this.commandsProvider.executeCommand('workbench.action.files.save');
     }
 
     private async executeTaskDefinition(definition: BuildTaskDefinition): Promise<vscode.TaskExecution> {

--- a/src/tasks/build/build-runner.test.ts
+++ b/src/tasks/build/build-runner.test.ts
@@ -56,6 +56,21 @@ describe('BuildRunner', () => {
                 'some-solution',
                 '--active', '',
                 '--schema',
+            ]);
+        });
+
+        it('includes --skip-convert for setup task definition', () => {
+            const buildTaskDefinition: BuildTaskDefinition = {
+                type: 'some-task',
+                solution: 'some-solution',
+                setup: true,
+            };
+
+            expect(cbuildArgsFromTaskDefinition(buildTaskDefinition)).toEqual([
+                'setup',
+                'some-solution',
+                '--active', '',
+                '--schema',
                 '--skip-convert',
             ]);
         });
@@ -105,7 +120,7 @@ describe('BuildRunner', () => {
             expect(cbuildArgsFromTaskDefinition(buildTaskDefinition)).toEqual([
                 'some-solution',
                 '--active', 'some-active@set',
-                '--schema', '--skip-convert']);
+                '--schema']);
         });
 
         it('does not include the --packs option if explicitly disabled in the task definition', async () => {
@@ -118,7 +133,7 @@ describe('BuildRunner', () => {
             expect(cbuildArgsFromTaskDefinition(buildTaskDefinition)).toEqual([
                 'some-solution',
                 '--active', '',
-                '--schema', '--skip-convert']);
+                '--schema']);
         });
 
         it('does not include the --schema option if explicitly disabled in the task definition', async () => {
@@ -129,8 +144,7 @@ describe('BuildRunner', () => {
             };
 
             expect(cbuildArgsFromTaskDefinition(buildTaskDefinition)).toEqual([
-                'some-solution',
-                '--active', '', '--skip-convert'
+                'some-solution', '--active', ''
             ]);
         });
 
@@ -144,7 +158,7 @@ describe('BuildRunner', () => {
             expect(cbuildArgsFromTaskDefinition(buildTaskDefinition)).toEqual([
                 'some-solution',
                 '--active', '',
-                '--schema', '--skip-convert']);
+                '--schema']);
         });
     });
 

--- a/src/tasks/build/build-runner.ts
+++ b/src/tasks/build/build-runner.ts
@@ -89,7 +89,7 @@ export const cbuildArgsFromTaskDefinition = (definition: BuildTaskDefinition): s
         executionArgs.push('--output', outDir);
     }
 
-    if (!definition.rebuild && !definition.clean) {
+    if (definition.setup) {
         executionArgs.push('--skip-convert');
     }
 

--- a/src/tasks/build/build-stop-command.test.ts
+++ b/src/tasks/build/build-stop-command.test.ts
@@ -292,7 +292,7 @@ describe('BuildStopCommand', () => {
 
         const task = {
             execution: { task: { name: 'cbuild test-solution', definition: { type: BuildTaskProviderImpl.taskType, setup: true } } }
-        } as vscode.TaskProcessStartEvent;
+        } as unknown as vscode.TaskProcessStartEvent;
 
         // Call the handler
         onDidStartTaskProcessHandler(task);

--- a/src/tasks/build/build-stop-command.test.ts
+++ b/src/tasks/build/build-stop-command.test.ts
@@ -83,7 +83,7 @@ describe('BuildStopCommand', () => {
     });
 
     // sets VS Code context for execution states:
-    const expectedStates = ['idle', 'building'] as const;
+    const expectedStates = ['idle', 'building', 'setup'] as const;
 
     expectedStates.forEach((state) => {
         it(`sets VS Code context for execution state: ${state}`, () => {
@@ -282,6 +282,26 @@ describe('BuildStopCommand', () => {
             'setContext',
             `${PACKAGE_NAME}.buildState`,
             'building'
+        );
+    });
+
+    it('should set processStarted and set state to setup when setup task process starts', async () => {
+        await buildStopCommand.activate(extensionContextFactory());
+        // Add lifecycle for setup task
+        buildStopCommand['taskLifecycles'].set('cbuild test-solution', { name: 'cbuild test-solution', started: true, processStarted: false });
+
+        const task = {
+            execution: { task: { name: 'cbuild test-solution', definition: { type: BuildTaskProviderImpl.taskType, setup: true } } }
+        } as vscode.TaskProcessStartEvent;
+
+        // Call the handler
+        onDidStartTaskProcessHandler(task);
+        const lifecycle = buildStopCommand['taskLifecycles'].get('cbuild test-solution');
+        expect(lifecycle?.processStarted).toBe(true);
+        expect(vscode.commands.executeCommand).toHaveBeenCalledWith(
+            'setContext',
+            `${PACKAGE_NAME}.buildState`,
+            'setup'
         );
     });
 

--- a/src/tasks/build/build-stop-command.ts
+++ b/src/tasks/build/build-stop-command.ts
@@ -20,7 +20,7 @@ import { CommandsProvider } from '../../vscode-api/commands-provider';
 import * as vscode from 'vscode';
 import { BuildTaskProviderImpl } from './build-task-provider';
 
-type buildState = 'idle' | 'building';
+type buildState = 'idle' | 'building' | 'setup';
 
 interface TaskLifecycle {
     name: string;
@@ -67,7 +67,7 @@ export class BuildStopCommand {
                 lifecycle.processStarted = true;
             }
 
-            this.setExecutionState('building');
+            this.setExecutionState(task.definition?.setup ? 'setup' : 'building');
         });
 
         vscode.tasks.onDidEndTaskProcess(event => {

--- a/src/tasks/build/build-task-provider.test.ts
+++ b/src/tasks/build/build-task-provider.test.ts
@@ -14,11 +14,12 @@
  * limitations under the License.
  */
 
-import { BuildTaskProviderImpl } from './build-task-provider';
+import { BuildTaskProviderImpl, waitForActiveBuildTasksCompletion } from './build-task-provider';
 import { cbuildArgsFromTaskDefinition } from './build-runner';
 import { Runner } from '../../vscode-api/runner/runner';
 import * as path from 'path';
 import { BuildTaskDefinition } from './build-task-definition';
+import * as vscode from 'vscode';
 
 interface MockCustomExecution {
     callback: () => void;
@@ -125,5 +126,41 @@ describe('BuildTaskProviderImpl', () => {
         const provider = new BuildTaskProviderImpl(mockRunner, 'Build');
         const result = provider.terminateTask('Build');
         expect(result).toBe(false);
+    });
+
+    it('waitForActiveBuildTasksCompletion resolves immediately when no active build tasks exist', async () => {
+        (vscode.tasks as unknown as { taskExecutions: vscode.TaskExecution[] }).taskExecutions = [];
+
+        await expect(waitForActiveBuildTasksCompletion()).resolves.toBeUndefined();
+    });
+
+    it('waitForActiveBuildTasksCompletion waits until active build task ends', async () => {
+        const activeExecution = {
+            task: { definition: { type: BuildTaskProviderImpl.taskType } }
+        } as unknown as vscode.TaskExecution;
+        const callbacks: Array<(event: vscode.TaskEndEvent) => void> = [];
+
+        (vscode.tasks as unknown as {
+            taskExecutions: vscode.TaskExecution[];
+            onDidEndTask: (listener: (event: vscode.TaskEndEvent) => void) => vscode.Disposable;
+        }).taskExecutions = [activeExecution];
+        (vscode.tasks as unknown as {
+            onDidEndTask: (listener: (event: vscode.TaskEndEvent) => void) => vscode.Disposable;
+        }).onDidEndTask = (listener) => {
+            callbacks.push(listener);
+            return { dispose: jest.fn() } as unknown as vscode.Disposable;
+        };
+
+        let completed = false;
+        const waitPromise = waitForActiveBuildTasksCompletion().then(() => {
+            completed = true;
+        });
+
+        await Promise.resolve();
+        expect(completed).toBe(false);
+
+        callbacks[0]({ execution: activeExecution } as vscode.TaskEndEvent);
+        await waitPromise;
+        expect(completed).toBe(true);
     });
 });

--- a/src/tasks/build/build-task-provider.test.ts
+++ b/src/tasks/build/build-task-provider.test.ts
@@ -163,4 +163,30 @@ describe('BuildTaskProviderImpl', () => {
         await waitPromise;
         expect(completed).toBe(true);
     });
+
+    it('resolves if build task ended before listener registration (race condition)', async () => {
+        const activeExecution = {
+            task: { definition: { type: BuildTaskProviderImpl.taskType } }
+        } as unknown as vscode.TaskExecution;
+
+        // Initial snapshot shows the task as active
+        (vscode.tasks as unknown as {
+            taskExecutions: vscode.TaskExecution[];
+        }).taskExecutions = [activeExecution];
+
+        (vscode.tasks as unknown as {
+            onDidEndTask: (listener: (event: vscode.TaskEndEvent) => void) => vscode.Disposable;
+        }).onDidEndTask = (listener) => {
+            // After listener registration, the task is no longer active (simulating race condition)
+            (vscode.tasks as unknown as {
+                taskExecutions: vscode.TaskExecution[];
+            }).taskExecutions = [];
+            // Invoke listener callback on next tick (safe to do even if task already ended)
+            setTimeout(() => listener({ execution: activeExecution } as vscode.TaskEndEvent), 0);
+            return { dispose: jest.fn() } as unknown as vscode.Disposable;
+        };
+
+        // Should resolve without hanging, even though the task ended before the listener could catch the event
+        await expect(waitForActiveBuildTasksCompletion()).resolves.toBeUndefined();
+    });
 });

--- a/src/tasks/build/build-task-provider.ts
+++ b/src/tasks/build/build-task-provider.ts
@@ -29,6 +29,33 @@ export interface BuildTaskProvider {
     getActiveTaskRunner(taskName: string): TerminalTaskRunner | undefined;
 }
 
+export const isBuildTask = (task: vscode.Task): boolean =>
+    task.definition?.type === BuildTaskProviderImpl.taskType;
+
+export const waitForActiveBuildTasksCompletion = async (): Promise<void> => {
+    const activeExecutions = (vscode.tasks.taskExecutions ?? []).filter(execution => isBuildTask(execution.task));
+
+    if (activeExecutions.length === 0) {
+        return;
+    }
+
+    const pendingExecutions = new Set(activeExecutions);
+
+    await new Promise<void>((resolve) => {
+        const disposable = vscode.tasks.onDidEndTask((event) => {
+            if (!pendingExecutions.has(event.execution)) {
+                return;
+            }
+
+            pendingExecutions.delete(event.execution);
+            if (pendingExecutions.size === 0) {
+                disposable.dispose();
+                resolve();
+            }
+        });
+    });
+};
+
 export class BuildTaskProviderImpl implements BuildTaskProvider, vscode.TaskProvider {
     public static taskType = `${PACKAGE_NAME}.build`;
     private readonly activeTaskRunners = new Map<string, TerminalTaskRunner>();

--- a/src/tasks/build/build-task-provider.ts
+++ b/src/tasks/build/build-task-provider.ts
@@ -53,6 +53,19 @@ export const waitForActiveBuildTasksCompletion = async (): Promise<void> => {
                 resolve();
             }
         });
+
+        // Guard against missing an end event between the snapshot and listener registration.
+        // If a build task ended between the snapshot and now, remove it from pending.
+        const stillActive = new Set((vscode.tasks.taskExecutions ?? []).filter(execution => isBuildTask(execution.task)));
+        for (const exec of pendingExecutions) {
+            if (!stillActive.has(exec)) {
+                pendingExecutions.delete(exec);
+            }
+        }
+        if (pendingExecutions.size === 0) {
+            disposable.dispose();
+            resolve();
+        }
     });
 };
 


### PR DESCRIPTION
## Fixes
<!-- List the GitHub issue(s) this PR resolves (e.g. #123) -->
- https://github.com/Open-CMSIS-Pack/vscode-cmsis-solution/issues/265
- https://github.com/Open-CMSIS-Pack/vscode-cmsis-solution/issues/264

## Changes
<!-- List the changes this PR introduces -->
**Behavior changes**
* Fixed rebuild flag cleanup by limiting `--skip-convert` to the setup phase only.
* Ensured that any unsaved changes in the Manage Solution editor are saved before creating setup and build tasks.
* Ensured that setup and build tasks cannot run concurrently. Combined with toolbox queueing, this allows proper reuse of the task pseudo-terminal and prevents multiple terminal instances from being created.

**UI changes**
* When running the cbuild setup, the Build button no longer changes to a Stop button. Instead, it remains disabled until the cbuild setup completes.
* The status bar spinner now continues running until the cbuild setup has finished.
* If the user cancels the setup task before it completes, the Problems view displays the following error: `cbuild setup incomplete, use Refresh command`.

These improvements provide a more appropriate level of visibility for the setup process, which is primarily a background operation. If additional feedback is desired, we could consider adding further indicators.


## Screenshots
<!-- Show UI changes with screenshots to ease UX/UI feedback: -->

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [x] 🤖 This change is covered by unit tests (if applicable).
- [x] 🤹 Manual testing has been performed (if necessary).
- [x] 🛡️ Security impacts have been considered (if relevant).
- [x] 📖 Documentation updates are complete (if required).
- [x] 🧠 Third-party dependencies and TPIP updated (if required).
