### PR TITLE
Rework locked and missing packs visualization

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "csolution": {
     "uv2csolutionVersion": "1.6.0",
     "toolboxVersion": "nightly",
-    "rpcVersion": "0.0.10"
+    "rpcVersion": "0.0.11"
   },
   "scripts": {
     "preprepare": "npm run download:rpc-interface",

--- a/src/views/manage-components-packs/components-packs-webview-main.ts
+++ b/src/views/manage-components-packs/components-packs-webview-main.ts
@@ -524,9 +524,9 @@ export class ComponentsPacksWebviewMain {
     private async handleApplyComponentSet(): Promise<void> {
         await this.webviewManager.sendMessage({ type: 'SET_SOLUTION_STATE', stateMessage: 'Saving changes...' });
 
-        if (this.solutionManager.getCsolution()?.cbuildPackFile.isModified()) {
+        const cbuildPackModified = this.solutionManager.getCsolution()?.cbuildPackFile.isModified() ?? false;
+        if (cbuildPackModified) {
             await this.solutionManager.getCsolution()?.cbuildPackFile.save();
-            await this.handleRequestInitialData();
             this.unlinkRequests.clear();
         }
 
@@ -539,6 +539,11 @@ export class ComponentsPacksWebviewMain {
         this.componentTree = this.manageComponentsActions.mapComponentsFromService(await this.csolutionService.getComponentsTree({ context: activeContext, all: requestAll }));
         this.validations = await this.csolutionService.validateComponents({ context: activeContext });
         await this.projectFileUpdater.updateUsedItems(activeContext, projectFileName, usedItemsForProjectFileUpdate);
+
+        // Trigger refresh if cbuild-pack was modified to ensure solution is properly reloaded
+        if (cbuildPackModified) {
+            await this.solutionManager.refresh();
+        }
 
         await Promise.all([
             this.webviewManager.sendMessage({ type: 'SET_ERROR_MESSAGES', messages: [] }),

--- a/src/views/manage-components-packs/view/components/pack-properties.tsx
+++ b/src/views/manage-components-packs/view/components/pack-properties.tsx
@@ -237,7 +237,7 @@ export const PackPropertiesDialog: React.FC<PackPropertiesDialogProperties> = ({
                     {!firstReferencePath && (
                         <Card title="Update Pack" size="small">
                             <Row>
-                                <Col flex={3}>Latest Installed Pack:</Col>
+                                <Col flex={3}>Latest Compliant Pack Installed:</Col>
                                 <Col flex={5}>{latestInstalledPack}</Col>
                                 <Col flex={1}>
                                     <Tooltip title={<span>Update and remove lock in <a onClick={() => { if (openFile && cbuildPackPath) openFile(cbuildPackPath, false); }}><EditFilled /></a>{cbuildPackPath} {unlockOf && <><br />Pending unlock request will be committed on save</>}</span>}>

--- a/src/views/manage-components-packs/view/components/pack-properties.tsx
+++ b/src/views/manage-components-packs/view/components/pack-properties.tsx
@@ -120,6 +120,13 @@ export const PackPropertiesDialog: React.FC<PackPropertiesDialogProperties> = ({
         ];
 
     const packDisplayName = pack?.description !== 'Pack not installed' ? pack?.packId : '';
+    const lockedPackValue = pack?.references.find(reference => reference.locked?.trim())?.locked?.trim() ?? '';
+    const hasMissingReferences = Boolean(pack?.references.some(ref => ref.missing));
+    const showErrorFallback = !packDisplayName && (Boolean(lockedPackValue) || hasMissingReferences);
+    const fallbackUsedPackDisplay = !packDisplayName
+        ? (lockedPackValue || pack?.packId || '')
+        : '';
+    const errorRowStyle = { color: 'var(--vscode-list-errorForeground)' };
     const latestInstalledPack = latestUpgradable ? `${pack?.name}@${latestUpgradable}` : packDisplayName;
     const hasNewerOnlineVersion = !!pack?.latestOnlineVersion && !latestInstalledPack?.endsWith(pack.latestOnlineVersion);
     const onlineTooltip = hasNewerOnlineVersion ? <div>Latest version available online: {pack.latestOnlineVersion}</div> : undefined;
@@ -216,7 +223,13 @@ export const PackPropertiesDialog: React.FC<PackPropertiesDialogProperties> = ({
                                         <td>{(!firstReferencePath && openFile) ? <PackTitleLink packId={pack.packId} packName={packDisplayName} openFile={openFile} /> : packDisplayName}</td>
                                     </tr>
                                 ) : null}
-                                <tr><td>Description:</td><td>{pack.description}</td></tr>
+                                {showErrorFallback ? (
+                                    <tr style={errorRowStyle}>
+                                        <td>Used Pack:</td>
+                                        <td>{fallbackUsedPackDisplay}</td>
+                                    </tr>
+                                ) : null}
+                                <tr style={showErrorFallback ? errorRowStyle : undefined}><td>Description:</td><td>{pack.description}</td></tr>
                                 {firstReferencePath ? <tr><td>Path:</td><td>{firstReferencePath}</td></tr> : null}
                             </tbody>
                         </table>

--- a/src/views/manage-components-packs/view/components/packs-view.css
+++ b/src/views/manage-components-packs/view/components/packs-view.css
@@ -56,3 +56,11 @@
 .packs-view-root .description-column {
     max-width: 65vw;
 }
+
+.packs-view-root .packs-missing-row .packs-pack-column,
+.packs-view-root .packs-missing-row .packs-version-column,
+.packs-view-root .packs-missing-row .packs-description-column,
+.packs-view-root .packs-missing-row .packs-pack-column a,
+.packs-view-root .packs-missing-row .packs-description-column a {
+    color: var(--vscode-errorForeground);
+}

--- a/src/views/manage-components-packs/view/components/packs-view.test.tsx
+++ b/src/views/manage-components-packs/view/components/packs-view.test.tsx
@@ -136,6 +136,111 @@ describe('PacksView', () => {
         expect(tableContent).toContain('6.0.0');
     });
 
+    it('strips version qualifier prefix for missing packs', () => {
+        const missingPackState: ComponentsState = {
+            ...defaultState,
+            packs: [{
+                ...mockPack,
+                packId: 'ARM::CMSIS@>=7.13.0',
+                versionUsed: '@>=7.13.0',
+                references: [{ pack: 'ARM::CMSIS@>=7.13.0', origin: 'path/to/solution.cproject.yml', relOrigin: 'path/to/solution.cproject.yml', selected: false, missing: true }]
+            }]
+        };
+
+        const localContainer = document.createElement('div');
+        React.act(() => {
+            createRoot(localContainer).render(
+                <PacksView state={missingPackState} openFile={openFileMock} messageHandler={messageHandler} availablePacks={defaultState.availablePacks} />
+            );
+        });
+
+        const tableContent = localContainer.textContent || '';
+        expect(tableContent).toContain('7.13.0');
+        // The version column should show the clean version without qualifier prefix
+        const versionCells = localContainer.querySelectorAll('td');
+        const versionCell = Array.from(versionCells).find(td => td.textContent?.trim() === '7.13.0');
+        expect(versionCell).toBeDefined();
+    });
+
+    it('adds missing-row class when pack has missing references', () => {
+        const missingPackState: ComponentsState = {
+            ...defaultState,
+            packs: [{
+                ...mockPack,
+                references: [{ pack: 'ARM::CMSIS@>=7.13.0', origin: 'path/to/solution.cproject.yml', relOrigin: 'path/to/solution.cproject.yml', selected: false, missing: true }]
+            }]
+        };
+
+        const localContainer = document.createElement('div');
+        React.act(() => {
+            createRoot(localContainer).render(
+                <PacksView state={missingPackState} openFile={openFileMock} messageHandler={messageHandler} availablePacks={defaultState.availablePacks} />
+            );
+        });
+
+        const row = localContainer.querySelector('tr.ant-table-row');
+        expect(row?.classList.contains('packs-missing-row')).toBe(true);
+    });
+
+    it('shows empty version when no version is given in the pack id', () => {
+        const noVersionPackState: ComponentsState = {
+            ...defaultState,
+            packs: [{
+                ...mockPack,
+                name: 'TFM',
+                packId: 'Keil::TFM',
+                versionUsed: '',
+                references: [{ pack: 'Keil::TFM', origin: 'path/to/solution.cproject.yml', relOrigin: 'path/to/solution.cproject.yml', selected: false, missing: true }]
+            }]
+        };
+
+        const localContainer = document.createElement('div');
+        React.act(() => {
+            createRoot(localContainer).render(
+                <PacksView state={noVersionPackState} openFile={openFileMock} messageHandler={messageHandler} availablePacks={defaultState.availablePacks} />
+            );
+        });
+
+        const tableContent = localContainer.textContent || '';
+        // The pack name should appear (in the Software Pack column), but not in the Version column
+        expect(tableContent).toContain('TFM');
+        expect(tableContent).not.toContain('Keil::TFM');
+    });
+
+    it('derives missing version from missing reference pack id when row pack id has no version', () => {
+        const missingReferenceVersionState: ComponentsState = {
+            ...defaultState,
+            packs: [{
+                ...mockPack,
+                packId: 'ARM::CMSIS',
+                versionUsed: '',
+                references: [{
+                    pack: 'ARM::CMSIS@>=7.13.0',
+                    origin: 'path/to/solution.cproject.yml',
+                    relOrigin: 'path/to/solution.cproject.yml',
+                    selected: false,
+                    missing: true
+                }]
+            }]
+        };
+
+        const localContainer = document.createElement('div');
+        React.act(() => {
+            createRoot(localContainer).render(
+                <PacksView
+                    state={missingReferenceVersionState}
+                    openFile={openFileMock}
+                    messageHandler={messageHandler}
+                    availablePacks={defaultState.availablePacks}
+                />
+            );
+        });
+
+        const versionCells = localContainer.querySelectorAll('td');
+        const versionCell = Array.from(versionCells).find(td => td.textContent?.trim() === '7.13.0');
+        expect(versionCell).toBeDefined();
+    });
+
     describe('pack properties dialog', () => {
         it('opens pack properties dialog when edit button is clicked', () => {
             const tableRows = container.querySelectorAll('.ant-table-row-level-0');
@@ -285,6 +390,99 @@ describe('PacksView', () => {
     });
 
     describe('references tooltip', () => {
+        it('shows version in tooltip from pack id even when locked is present', () => {
+            const stateWithLockedReference: ComponentsState = {
+                ...defaultState,
+                packs: [{
+                    ...mockPack,
+                    references: [{
+                        ...mockPack.references[0],
+                        pack: 'ARM::CMSIS@5.9.0',
+                        locked: 'ARM::CMSIS@6.1.0',
+                        relPath: ''
+                    }]
+                }]
+            };
+
+            const localContainer = document.createElement('div');
+            React.act(() => {
+                createRoot(localContainer).render(
+                    <PacksView
+                        state={stateWithLockedReference}
+                        openFile={openFileMock}
+                        messageHandler={messageHandler}
+                        availablePacks={defaultState.availablePacks}
+                    />
+                );
+            });
+
+            const tableContent = localContainer.textContent || '';
+            expect(tableContent).toContain('(5.9.0)');
+            expect(tableContent).not.toContain('(6.1.0)');
+        });
+
+        it('does not show tooltip version when reference pack id does not provide a version', () => {
+            const stateWithLockedOnlyVersion: ComponentsState = {
+                ...defaultState,
+                packs: [{
+                    ...mockPack,
+                    packId: 'ARM::CMSIS',
+                    references: [{
+                        ...mockPack.references[0],
+                        pack: 'ARM::CMSIS',
+                        locked: 'ARM::CMSIS@6.1.0',
+                        relPath: ''
+                    }]
+                }]
+            };
+
+            const localContainer = document.createElement('div');
+            React.act(() => {
+                createRoot(localContainer).render(
+                    <PacksView
+                        state={stateWithLockedOnlyVersion}
+                        openFile={openFileMock}
+                        messageHandler={messageHandler}
+                        availablePacks={defaultState.availablePacks}
+                    />
+                );
+            });
+
+            const tableContent = localContainer.textContent || '';
+            expect(tableContent).not.toContain('(6.1.0)');
+        });
+
+        it('shows missing pack version in tooltip without @ prefix', () => {
+            const stateWithMissingReference: ComponentsState = {
+                ...defaultState,
+                packs: [{
+                    ...mockPack,
+                    references: [{
+                        ...mockPack.references[0],
+                        pack: 'ARM::CMSIS@>=6.1.0',
+                        missing: true,
+                        relPath: ''
+                    }]
+                }]
+            };
+
+            const localContainer = document.createElement('div');
+            React.act(() => {
+                createRoot(localContainer).render(
+                    <PacksView
+                        state={stateWithMissingReference}
+                        openFile={openFileMock}
+                        messageHandler={messageHandler}
+                        availablePacks={defaultState.availablePacks}
+                    />
+                );
+            });
+
+            const tableContent = localContainer.textContent || '';
+            expect(tableContent).toContain('(>=6.1.0)');
+            expect(tableContent).not.toContain('(@>=6.1.0)');
+        });
+
         it('shows a separate path line when relPath is defined and non-empty', () => {
             const stateWithRelPath: ComponentsState = {
                 ...defaultState,

--- a/src/views/manage-components-packs/view/components/packs-view.tsx
+++ b/src/views/manage-components-packs/view/components/packs-view.tsx
@@ -151,17 +151,18 @@ export const PacksView: React.FC<PacksProps> = ({ state, openFile, messageHandle
         const renderVersionTarget = (_value: string, record: PackRowDataType) => {
             const usedVersion = record.versionUsed.replace(/^[~^<>=@\s]+/, '');
             const lockedReference = record.references
-                .map(reference => reference.locked?.trim())
-                .find((locked): locked is string => Boolean(locked));
+                .find(reference => Boolean(reference.locked?.trim()))
+                ?.locked?.trim();
             const lockedVersion = lockedReference
                 ? (parsePackId(lockedReference)?.version || lockedReference.replace(/^.*@/, ''))
                 : '';
             const missingReference = record.references
-                .find(reference => reference.missing && Boolean(reference.pack?.trim()));
+                .find(reference => reference.missing && Boolean(reference.pack?.trim()))
+                ?.pack;
             const missingVersion = missingReference && !lockedReference
-                ? (parsePackId(missingReference.pack)?.version ?? '')
+                ? (parsePackId(missingReference)?.version ?? '')
                 : '';
-            const version = usedVersion || lockedVersion || missingVersion;
+            const version = lockedVersion || usedVersion || missingVersion;
             return (
                 <span>
                     {version}

--- a/src/views/manage-components-packs/view/components/packs-view.tsx
+++ b/src/views/manage-components-packs/view/components/packs-view.tsx
@@ -74,12 +74,14 @@ export const PacksView: React.FC<PacksProps> = ({ state, openFile, messageHandle
         };
 
         const renderPackColumn = (_value: string, record: PackRowDataType) => {
-            const pack = parsePackId(record.packId);
             const packTitle = <PackTitleLink packId={record.packId} packName={record.name} openFile={openFile} />;
             const referencedFrom = [
                 <div key='pack-name'>{packTitle}</div>,
                 ...(record.references?.map((ref, index) => {
-                    const p = parsePackId(ref.pack);
+                    const referencePack = parsePackId(ref.pack);
+                    const displayedVersionOperator = referencePack?.versionOperator ?? '';
+                    const normalizedVersionOperator = displayedVersionOperator.replace(/^@/, '');
+                    const displayedVersion = referencePack?.version ?? '';
                     const hasRelPath = Boolean(ref.relPath?.trim());
 
                     return (
@@ -92,7 +94,7 @@ export const PacksView: React.FC<PacksProps> = ({ state, openFile, messageHandle
                                         openFile(ref.origin, false, `- pack: ${ref.pack}`);
                                     }
                                     return false;
-                                }}><EditFilled /></a> ./{ref.relOrigin} <span className='faded'>({p?.versionOperator}{p?.version ?? pack?.version})</span>
+                                }}><EditFilled /></a> ./{ref.relOrigin} <span className='faded'>{displayedVersion ? `(${normalizedVersionOperator}${displayedVersion})` : ''}</span>
                             </div>
                             {hasRelPath ? (
                                 <div>path: {ref.relPath}</div>
@@ -147,7 +149,19 @@ export const PacksView: React.FC<PacksProps> = ({ state, openFile, messageHandle
         };
 
         const renderVersionTarget = (_value: string, record: PackRowDataType) => {
-            const version = record.versionUsed.replaceAll('@', '');
+            const usedVersion = record.versionUsed.replace(/^[~^<>=@\s]+/, '');
+            const lockedReference = record.references
+                .map(reference => reference.locked?.trim())
+                .find((locked): locked is string => Boolean(locked));
+            const lockedVersion = lockedReference
+                ? (parsePackId(lockedReference)?.version || lockedReference.replace(/^.*@/, ''))
+                : '';
+            const missingReference = record.references
+                .find(reference => reference.missing && Boolean(reference.pack?.trim()));
+            const missingVersion = missingReference && !lockedReference
+                ? (parsePackId(missingReference.pack)?.version ?? '')
+                : '';
+            const version = usedVersion || lockedVersion || missingVersion;
             return (
                 <span>
                     {version}
@@ -156,10 +170,10 @@ export const PacksView: React.FC<PacksProps> = ({ state, openFile, messageHandle
         };
 
         return [
-            { title: 'Software Pack', dataIndex: 'name', key: 'name', width: 240, ellipsis: true, render: renderPackColumn },
+            { title: 'Software Pack', dataIndex: 'name', key: 'name', width: 240, ellipsis: true, render: renderPackColumn, onCell: () => ({ className: 'packs-pack-column' }) },
             { title: 'Select', render: (record: PackRowDataType) => renderEditColumn(record), width: 64 },
-            { title: 'Version', dataIndex: 'versionTarget', key: 'versionTarget', minWidth: 120, ellipsis: false, render: renderVersionTarget },
-            { title: 'Description', dataIndex: 'description', key: 'description', ellipsis: true, render: renderDescriptionCell, onCell: () => ({ className: 'description-column' }) },
+            { title: 'Version', dataIndex: 'versionTarget', key: 'versionTarget', minWidth: 120, ellipsis: false, render: renderVersionTarget, onCell: () => ({ className: 'packs-version-column' }) },
+            { title: 'Description', dataIndex: 'description', key: 'description', ellipsis: true, render: renderDescriptionCell, onCell: () => ({ className: 'description-column packs-description-column' }) },
         ];
     }, [openFile, selectPack]);
 
@@ -225,8 +239,17 @@ export const PacksView: React.FC<PacksProps> = ({ state, openFile, messageHandle
     const rowClassName = (record: PackRowDataType): string => {
         const relativePath = state.selectedTargetType?.relativePath || '';
         const selectedInCurrentTarget = referenceFromContext(relativePath, record).length > 0;
+        const hasMissingReferences = record.references.some(ref => ref.missing);
 
-        return !selectedInCurrentTarget ? '' : 'ant-table-row-disabled';
+        const classes: string[] = [];
+        if (selectedInCurrentTarget) {
+            classes.push('ant-table-row-disabled');
+        }
+        if (hasMissingReferences) {
+            classes.push('packs-missing-row');
+        }
+
+        return classes.join(' ');
     };
 
     return (


### PR DESCRIPTION
## Fixes
<!-- List the GitHub issue(s) this PR resolves (e.g. #123) -->
- https://github.com/Open-CMSIS-Pack/vscode-cmsis-solution/issues/255
- https://github.com/Open-CMSIS-Pack/vscode-cmsis-solution/issues/226

## Changes
<!-- List the changes this PR introduces -->
Improves how locked and missing packs are displayed in the Software Packs view and Manage Pack dialog (pack properties), making problem states clearly visible to the user via error-coloured styling and better version string rendering.
- Software Packs view:
  - version column: extracts and displays the version from a locked reference or from the pack ID when all references are missing, so a version is shown even when the pack is not installed.
  - references tooltip: correct what is displayed in the tooltip to be consistent with the entries in yml files.
  - added CSS rules targeting packs-missing-row to colour the pack name, version, and reference columns.
- Manage Pack dialog:
  - when the pack has missing references, even if locked, the `Used Pack` and the `Description` adopts the error colour.
  - fixed `Latest Installed Pack` to be consistent with `upgrade` version reported via RPC, even for locked but not installed packs.
  - trigger refresh if cbuild-pack is modified to ensure solution is properly reloaded
- added test cases
- bumped csolution RPC interface to 0.0.11.

## Screenshots
<!-- Show UI changes with screenshots to ease UX/UI feedback: -->
Pack view with not installed pack and tooltip showing pack with multiple references:
<img width="1101" height="319" alt="image" src="https://github.com/user-attachments/assets/a706501e-ebf3-4e00-8288-e8fc5ba6d276" />

Pack properties dialog with locked but not installed pack:
<img width="504" height="508" alt="image" src="https://github.com/user-attachments/assets/fb71d0dc-4c31-49af-9956-0616add6821f" />




## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [x] 🤖 This change is covered by unit tests (if applicable).
- [x] 🤹 Manual testing has been performed (if necessary).
- [x] 🛡️ Security impacts have been considered (if relevant).
- [x] 📖 Documentation updates are complete (if required).
- [x] 🧠 Third-party dependencies and TPIP updated (if required).
