### PR TITLE
Rework Build button behaviour

### DIFF
--- a/package.json
+++ b/package.json
@@ -447,7 +447,7 @@
         "command": "cmsis-csolution.build",
         "title": "Build Solution",
         "icon": "$(csolution-build)",
-        "enablement": "cmsis-csolution.activeSolutionState == active && cmsis-csolution.buildState == idle"
+        "enablement": "cmsis-csolution.activeSolutionState == active && (cmsis-csolution.buildState == idle || cmsis-csolution.buildState == setup)"
       },
       {
         "category": "CMSIS",

--- a/src/solutions/files/cbuild-idx-file.ts
+++ b/src/solutions/files/cbuild-idx-file.ts
@@ -125,6 +125,13 @@ class CbuildIdxFileImpl extends CTreeItemYamlFile implements CbuildIdxFile {
             this._cbuildFiles.set(context.projectName, cbuildFile);
         }
 
+        // Do not attempt to load cbuild file if it does not exist
+        cbuildFile.fileName = resolvedPath;
+        if (!cbuildFile.exists()) {
+            this._activeContexts.push(context);
+            return ETextFileResult.NotExists;
+        }
+
         const result = await cbuildFile.load(resolvedPath);
         if (result <= ETextFileResult.Success) {
             context.projectPath = cbuildFile.projectPath;

--- a/src/solutions/intellisense/compile-commands-generator.test.ts
+++ b/src/solutions/intellisense/compile-commands-generator.test.ts
@@ -217,24 +217,7 @@ describe('CompileCommandsGenerator', () => {
         });
     });
 
-    it('reports error with incomplete setup message when task is aborted', async () => {
-        (mockBuildTaskProvider.getActiveTaskRunner as jest.Mock).mockReturnValue({
-            getOutputBuffer: () => []
-        });
-        exitCode = -1;
-        cbuildSetupRequestedListener?.();
-        await waitTimeout();
-
-        expect(mockEventHub.fireCbuildCompleted).toHaveBeenCalledWith(
-            expect.objectContaining({
-                success: false,
-                severity: 'error',
-                toolsOutputMessages: expect.arrayContaining([expect.stringContaining('cbuild setup incomplete, use Refresh command')])
-            })
-        );
-    });
-
-    it('does not append incomplete setup message when exit code is -1 but tool output already contains an error', async () => {
+    it('reports error severity when output contains an error pattern even without parsed exit code', async () => {
         (mockBuildTaskProvider.getActiveTaskRunner as jest.Mock).mockReturnValue({
             getOutputBuffer: () => ['error cbuild: failed to generate']
         });
@@ -243,7 +226,7 @@ describe('CompileCommandsGenerator', () => {
         await waitTimeout();
 
         expect(mockEventHub.fireCbuildCompleted).toHaveBeenCalledWith({
-            success: false,
+            success: true,
             severity: 'error',
             toolsOutputMessages: ['error cbuild: failed to generate']
         });

--- a/src/solutions/intellisense/compile-commands-generator.ts
+++ b/src/solutions/intellisense/compile-commands-generator.ts
@@ -86,7 +86,7 @@ export class CompileCommandsGenerator {
                     disposable.dispose();
                     const output = this.buildTaskProvider.getActiveTaskRunner(task.name)?.getOutputBuffer() ?? [];
                     const match = this.outputRegex.exec(output.join('\n'));
-                    // 'success' strictly reflects process outcome reported in the output
+                    // 'success' reflects process outcome reported in the output, ignoring when the task was terminated early
                     const success = Number(match?.[1] ?? 0) === 0;
                     // 'severity' is determined based on output content to properly report errors/warnings
                     const severity = success ? getToolsSeverity(output) : 'error';

--- a/src/solutions/intellisense/compile-commands-generator.ts
+++ b/src/solutions/intellisense/compile-commands-generator.ts
@@ -86,19 +86,11 @@ export class CompileCommandsGenerator {
                     disposable.dispose();
                     const output = this.buildTaskProvider.getActiveTaskRunner(task.name)?.getOutputBuffer() ?? [];
                     const match = this.outputRegex.exec(output.join('\n'));
-                    const returnCode = match?.[1] !== undefined ? Number(match[1]) :
-                        event.exitCode !== undefined ? event.exitCode : -1;
-
-                    const outputSeverity = getToolsSeverity(output);
-                    // Detect task abort (exit code -1 without tool-reported error indicates user termination)
-                    const isAborted = returnCode === -1 && outputSeverity !== 'error';
-                    if (isAborted) {
-                        output.push('error cbuild: cbuild setup incomplete, use Refresh command');
-                    }
-
-                    const success = returnCode === 0;
-                    const severity = isAborted ? 'error' : (success ? outputSeverity : 'error');
-                    this.eventHub.fireCbuildCompleted({ success: isAborted ? false : success, severity, toolsOutputMessages: output });
+                    // 'success' strictly reflects process outcome reported in the output
+                    const success = Number(match?.[1] ?? 0) === 0;
+                    // 'severity' is determined based on output content to properly report errors/warnings
+                    const severity = success ? getToolsSeverity(output) : 'error';
+                    this.eventHub.fireCbuildCompleted({ success, severity, toolsOutputMessages: output });
                     resolve();
                 }
             });

--- a/src/tasks/build/build-command.test.ts
+++ b/src/tasks/build/build-command.test.ts
@@ -99,6 +99,80 @@ describe('BuildCommand', () => {
             });
         });
 
+        it('stops active setup task via provider before starting build', async () => {
+            const setupTask = {
+                name: 'cbuild setup-solution',
+                definition: { type: BuildTaskProviderImpl.taskType, setup: true }
+            } as unknown as vscode.Task;
+
+            (vscode.tasks as unknown as {
+                taskExecutions: vscode.TaskExecution[];
+            }).taskExecutions = [
+                {
+                    task: setupTask,
+                    terminate: jest.fn()
+                } as unknown as vscode.TaskExecution
+            ];
+
+            mockBuildTaskProvider.terminateTask = jest.fn().mockImplementation(() => {
+                (vscode.tasks as unknown as {
+                    taskExecutions: vscode.TaskExecution[];
+                }).taskExecutions = [];
+                return true;
+            });
+
+            const buildCommand = new BuildCommand(
+                mockBuildTaskProvider,
+                commandsProvider,
+                buildTaskDefinitionBuilder,
+            );
+            await buildCommand.activate({ subscriptions: [] } as unknown as vscode.ExtensionContext);
+
+            await commandsProvider.mockRunRegistered(BuildCommand.buildCommandType, undefined);
+
+            expect(mockBuildTaskProvider.terminateTask).toHaveBeenCalledWith('cbuild setup-solution');
+            expect(buildTaskDefinitionBuilder.createDefinitionFromUriOrSolutionNode).toHaveBeenCalledWith('build', undefined);
+            expect(mockExecuteTask).toHaveBeenCalledTimes(1);
+        });
+
+        it('falls back to task execution terminate when provider cannot stop setup task', async () => {
+            const terminateSpy = jest.fn().mockImplementation(() => {
+                (vscode.tasks as unknown as {
+                    taskExecutions: vscode.TaskExecution[];
+                }).taskExecutions = [];
+            });
+
+            const setupTask = {
+                name: 'cbuild setup-solution',
+                definition: { type: BuildTaskProviderImpl.taskType, setup: true }
+            } as unknown as vscode.Task;
+
+            (vscode.tasks as unknown as {
+                taskExecutions: vscode.TaskExecution[];
+            }).taskExecutions = [
+                {
+                    task: setupTask,
+                    terminate: terminateSpy
+                } as unknown as vscode.TaskExecution
+            ];
+
+            mockBuildTaskProvider.terminateTask = jest.fn().mockReturnValue(false);
+
+            const buildCommand = new BuildCommand(
+                mockBuildTaskProvider,
+                commandsProvider,
+                buildTaskDefinitionBuilder,
+            );
+            await buildCommand.activate({ subscriptions: [] } as unknown as vscode.ExtensionContext);
+
+            await commandsProvider.mockRunRegistered(BuildCommand.buildCommandType, undefined);
+
+            expect(mockBuildTaskProvider.terminateTask).toHaveBeenCalledWith('cbuild setup-solution');
+            expect(terminateSpy).toHaveBeenCalledTimes(1);
+            expect(buildTaskDefinitionBuilder.createDefinitionFromUriOrSolutionNode).toHaveBeenCalledWith('build', undefined);
+            expect(mockExecuteTask).toHaveBeenCalledTimes(1);
+        });
+
     });
 
     describe('rebuild command', () => {

--- a/src/tasks/build/build-command.ts
+++ b/src/tasks/build/build-command.ts
@@ -18,7 +18,7 @@ import * as vscode from 'vscode';
 import { PACKAGE_NAME } from '../../manifest';
 import { CommandsProvider } from '../../vscode-api/commands-provider';
 import { BuildTaskDefinition } from './build-task-definition';
-import { BuildTaskProvider, waitForActiveBuildTasksCompletion } from './build-task-provider';
+import { BuildTaskProvider, BuildTaskProviderImpl, waitForActiveBuildTasksCompletion } from './build-task-provider';
 import { BuildTaskDefinitionBuilder } from './build-task-definition-builder';
 import { COutlineItem } from '../../views/solution-outline/tree-structure/solution-outline-item';
 
@@ -56,10 +56,26 @@ export class BuildCommand {
     }
 
     private async createAndExecuteTaskDefinition(action: 'build' | 'clean' | 'rebuild', uriOrSolutionNode?: UriOrSolutionNode): Promise<vscode.TaskExecution> {
+        await this.stopActiveSetupTaskIfRunning();
         await waitForActiveBuildTasksCompletion();
         await this.saveDirtyManageSolutionTarget();
         const definition = await this.buildTaskDefinitionBuilder.createDefinitionFromUriOrSolutionNode(action, uriOrSolutionNode);
         return this.executeTaskDefinition(definition);
+    }
+
+    private async stopActiveSetupTaskIfRunning(): Promise<void> {
+        const setupExecution = (vscode.tasks.taskExecutions ?? []).find(execution =>
+            execution.task.definition?.type === BuildTaskProviderImpl.taskType && execution.task.definition?.setup === true
+        );
+
+        if (!setupExecution) {
+            return;
+        }
+
+        const taskName = setupExecution.task.name;
+        if (!taskName || !this.buildTaskProvider.terminateTask(taskName)) {
+            setupExecution.terminate();
+        }
     }
 
     private async saveDirtyManageSolutionTarget(): Promise<void> {

--- a/src/tasks/build/build-task-provider.ts
+++ b/src/tasks/build/build-task-provider.ts
@@ -147,7 +147,8 @@ export class BuildTaskProviderImpl implements BuildTaskProvider, vscode.TaskProv
                     taskName: taskLabel,
                     runMessage: this.taskMessages.runMessage,
                     completeMessage: this.taskMessages.completeMessage,
-                    terminationMessage: this.taskMessages.terminationMessage,
+                    terminationMessage: resolvedTaskDefinition.setup ? '\r\n🟥 Build requested by user, skip setup\r\n' :
+                        this.taskMessages.terminationMessage,
                     dimensions: resolvedTaskDefinition.dimensions,
                 });
                 // Use the generated task name for tracking


### PR DESCRIPTION
## Changes
<!-- List the changes this PR introduces -->
- Build button remains active during setup phase. Command flow now terminates active setup task before proceeding with build task.
- Update setup task outcome evaluation to cope with the task termination above.
- Cbuild loader now skips calling `cbuildFile.load` when the file is not yet created, avoiding a noisy notification.
- Add/update test cases.

## Screenshots
<!-- Show UI changes with screenshots to ease UX/UI feedback: -->

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [x] 🤖 This change is covered by unit tests (if applicable).
- [x] 🤹 Manual testing has been performed (if necessary).
- [x] 🛡️ Security impacts have been considered (if relevant).
- [x] 📖 Documentation updates are complete (if required).
- [x] 🧠 Third-party dependencies and TPIP updated (if required).
