### PR TITLE
Remove rerun-failed-jobs from nightly.yml

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -307,36 +307,3 @@ jobs:
         with:
           name: e2e-screenshots
           path: e2e-screenshots
-
-  # Automatically recover from transient infra/network issues by rerunning
-  # only failed jobs once
-  rerun-failed-jobs:
-    needs: [ test ]
-    if: >-
-      failure() &&
-      github.repository == 'Open-CMSIS-Pack/vscode-cmsis-solution' &&
-      github.event_name == 'workflow_dispatch' &&
-      github.run_attempt == 1
-    permissions:
-      actions: write
-      contents: read
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
-        with:
-          egress-policy: audit
-
-      - name: Re-run failed jobs
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          API_URL="https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/rerun-failed-jobs"
-          echo "Requesting rerun of failed jobs for run ${{ github.run_id }}"
-
-          curl --fail-with-body --show-error --silent \
-            -X POST \
-            -H "Authorization: Bearer ${GH_TOKEN}" \
-            -H "Accept: application/vnd.github+json" \
-            "${API_URL}"


### PR DESCRIPTION
## Changes
- GitHub rejects rerun calls from inside the same in-progress workflow run

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [x] 🤖 This change is covered by unit tests (if applicable).
- [x] 🤹 Manual testing has been performed (if necessary).
- [x] 🛡️ Security impacts have been considered (if relevant).
- [x] 📖 Documentation updates are complete (if required).
- [x] 🧠 Third-party dependencies and TPIP updated (if required).
