### PR TITLE
Replace TPIP report timestamp with associated release identifier

### DIFF
--- a/.github/workflows/tpip.yml
+++ b/.github/workflows/tpip.yml
@@ -57,25 +57,22 @@ jobs:
         run: npm ci
 
       - name: Update TPIP excerpt
-        id: excerpt
+        run: npm run tpip:update
+
+      - name: Update TPIP report
+        id: report
         run: |
-          npm run tpip:update
-          if git diff --exit-code docs/third-party-licenses.json > /dev/null; then
+          npm run tpip
+          if git diff --exit-code docs/third-party-licenses.md > /dev/null; then
             echo "update=0" >> $GITHUB_OUTPUT
           else
             echo "update=1" >> $GITHUB_OUTPUT
           fi
 
-      - name: Update TPIP report
-        if: ${{ steps.excerpt.outputs.update == 1 }}
-        run: npm run tpip
-
       - name: Commit Changes
-        if: ${{ steps.excerpt.outputs.update == 1 }}
+        if: ${{ steps.report.outputs.update == 1 }}
         uses: EndBug/add-and-commit@290ea2c423ad77ca9c62ae0f5b224379612c0321
         with:
-          author_name: monty-bot
-          author_email: monty-bot@arm.com
           message: "Update TPIP report [skip ci]"
           add: |
             docs/third-party-licenses.*

--- a/docs/third-party-licenses.md
+++ b/docs/third-party-licenses.md
@@ -1,6 +1,6 @@
 # TPIP Report for vscode-cmsis-solution
 
-Generated for release: 
+Generated for release: 1.68.0
 
 | *Package* | *Version* | *Repository* | *License* |
 |---|---|---|---|

--- a/docs/third-party-licenses.md
+++ b/docs/third-party-licenses.md
@@ -1,6 +1,6 @@
 # TPIP Report for vscode-cmsis-solution
 
-Report prepared at: 12/06/2026, 09:39:35
+Generated for release: 
 
 | *Package* | *Version* | *Repository* | *License* |
 |---|---|---|---|

--- a/scripts/tpip-reporter.ts
+++ b/scripts/tpip-reporter.ts
@@ -23,7 +23,7 @@ import fs from "fs";
 async function main() {
 
     const argv = yargs(hideBin(process.argv))
-        .usage('Usage: $0 <json> <report> [--header <header>]')
+        .usage('Usage: $0 <json> <report> [--header <header>] [--release <release>]')
         .options('header', {
             describe: 'Header to add to the report',
             type: 'string'
@@ -49,6 +49,12 @@ async function main() {
     const report = argv.report as string;
     const header = argv.header;
 
+    let release: string | undefined;
+    if (fs.existsSync('package.json')) {
+        const packageJson = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+        release = packageJson.version;
+    }
+
     const tpipJson = JSON.parse(fs.readFileSync(json, "utf8"));
 
     // Sort packages alphabetically by name for better readability
@@ -62,7 +68,7 @@ async function main() {
     }
 
     data += '\n';
-    data += `Report prepared at: ${new Date().toLocaleString('en-GB')}\n\n`;
+    data += `Generated for release: ${release ?? 'unknown'}\n\n`;
     data += '| *Package* | *Version* | *Repository* | *License* |\n';
     data += '|---|---|---|---|\n';
 

--- a/scripts/tpip-reporter.ts
+++ b/scripts/tpip-reporter.ts
@@ -23,7 +23,7 @@ import fs from "fs";
 async function main() {
 
     const argv = yargs(hideBin(process.argv))
-        .usage('Usage: $0 <json> <report> [--header <header>] [--release <release>]')
+        .usage('Usage: $0 <json> <report> [--header <header>]')
         .options('header', {
             describe: 'Header to add to the report',
             type: 'string'


### PR DESCRIPTION
## Changes
- The TPIP report previously embedded a generation timestamp. The report now records the associated release.

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [x] 🤖 This change is covered by unit tests (if applicable).
- [x] 🤹 Manual testing has been performed (if necessary).
- [x] 🛡️ Security impacts have been considered (if relevant).
- [x] 📖 Documentation updates are complete (if required).
- [x] 🧠 Third-party dependencies and TPIP updated (if required).
