### PR TITLE
fix: write cproject files before csolution to prevent file watcher race condition

### DIFF
--- a/src/data-manager/draft-project-data.ts
+++ b/src/data-manager/draft-project-data.ts
@@ -22,7 +22,7 @@ import { tmpdir } from 'os';
 import extractZip from 'extract-zip';
 import { downloadFile } from '../file-download';
 import { workspaceFsProvider } from '../vscode-api/workspace-fs-provider';
-import { copyFolderRecursive, copyFilesOnly } from '../utils/fs-utils';
+import { copyFolderRecursive, copyFilesOnly, copyFolderRecursiveDeferred } from '../utils/fs-utils';
 
 import { ExampleProject as CsolutionExampleProject, ExampleEnvironment as CsolutionExampleEnvironment, SolutionTemplate as CsolutionTemplate } from '../json-rpc/csolution-rpc-client';
 import { splitPackId } from '../json-rpc/csolution-rpc-helper';
@@ -260,18 +260,7 @@ export class CsolutionTemplateData extends BaseDraftProjectData {
     }
 
     public async copyTo(dest: string) {
-        // DFP pack templates place shared files (e.g. Blank.cproject.yml, main.c)
-        // one level above the device-specific solution subfolder. The csolution
-        // references those files via '../' relative paths. Vendor packs have no
-        // guaranteed write order — any file in the template folder may appear
-        // before or after the .csolution.yml. Copying parent-level files BEFORE
-        // copying the subfolder (which contains the .csolution.yml) ensures every
-        // referenced file already exists when the file watcher fires on the
-        // csolution write, eliminating the "cproject not parsed" race.
-        const templateParent = path.dirname(this.data.folder);
-        const destParent = path.dirname(dest);
-        copyFilesOnly(templateParent, destParent);
-
-        return copyFolderRecursive(this.data.folder, dest);
+        copyFilesOnly(path.dirname(this.data.folder), path.dirname(dest));
+        copyFolderRecursiveDeferred(this.data.folder, dest, '.csolution.yml');
     }
 }

--- a/src/data-manager/draft-project-data.ts
+++ b/src/data-manager/draft-project-data.ts
@@ -22,7 +22,7 @@ import { tmpdir } from 'os';
 import extractZip from 'extract-zip';
 import { downloadFile } from '../file-download';
 import { workspaceFsProvider } from '../vscode-api/workspace-fs-provider';
-import { copyFolderRecursive } from '../utils/fs-utils';
+import { copyFolderRecursive, copyFilesOnly } from '../utils/fs-utils';
 
 import { ExampleProject as CsolutionExampleProject, ExampleEnvironment as CsolutionExampleEnvironment, SolutionTemplate as CsolutionTemplate } from '../json-rpc/csolution-rpc-client';
 import { splitPackId } from '../json-rpc/csolution-rpc-helper';
@@ -260,6 +260,18 @@ export class CsolutionTemplateData extends BaseDraftProjectData {
     }
 
     public async copyTo(dest: string) {
+        // DFP pack templates place shared files (e.g. Blank.cproject.yml, main.c)
+        // one level above the device-specific solution subfolder. The csolution
+        // references those files via '../' relative paths. Vendor packs have no
+        // guaranteed write order — any file in the template folder may appear
+        // before or after the .csolution.yml. Copying parent-level files BEFORE
+        // copying the subfolder (which contains the .csolution.yml) ensures every
+        // referenced file already exists when the file watcher fires on the
+        // csolution write, eliminating the "cproject not parsed" race.
+        const templateParent = path.dirname(this.data.folder);
+        const destParent = path.dirname(dest);
+        copyFilesOnly(templateParent, destParent);
+
         return copyFolderRecursive(this.data.folder, dest);
     }
 }

--- a/src/solutions/solution-creator.ts
+++ b/src/solutions/solution-creator.ts
@@ -123,8 +123,6 @@ export class SolutionCreatorImp  implements SolutionCreator {
     private async createFiles(solutionDir: string, solutionPath: string, projectsWithPath: { project: NewProject, path: string }[]) {
         const solutionTemplatePath = path.resolve(TEMPLATES_FOLDER, 'template.csolution.yml');
         await promisify(mkdir)(solutionDir, { recursive: true });
-        await promisify(copyFile)(solutionTemplatePath, solutionPath);
-
         await Promise.all(projectsWithPath.map(async ({ project, path: projectPath }): Promise<void> => {
             const templateFileName = {
                 'secure': 'secure.cproject.yml',
@@ -138,6 +136,9 @@ export class SolutionCreatorImp  implements SolutionCreator {
 
             await promisify(copyFile)(path.join(TEMPLATES_FOLDER, 'c', 'main.c'), path.join(path.dirname(projectPath), 'main.c'));
         }));
+        // Write csolution last - the file watcher triggers ConvertSolution
+        // when it appears on disk, so all referenced cproject files must exist.
+        await promisify(copyFile)(solutionTemplatePath, solutionPath);
     }
 
     private getProjectComponents(): ComponentData[] {

--- a/src/utils/fs-utils.test.ts
+++ b/src/utils/fs-utils.test.ts
@@ -80,6 +80,36 @@ describe('copyFolderRecursive', () => {
     });
 });
 
+describe('copyFilesOnly', () => {
+    const testDataHandler = new TestDataHandler();
+    const tempDir = testDataHandler.tmpDir;
+    const srcDir = path.join(tempDir, 'copyFilesOnlySrc');
+    const destDir = path.join(tempDir, 'copyFilesOnlyDest');
+
+    beforeAll(async () => {
+        await fs.mkdir(srcDir);
+        await fs.writeFile(path.join(srcDir, 'file1.txt'), 'text1');
+        await fs.writeFile(path.join(srcDir, 'file2.txt'), 'text2');
+        await fs.mkdir(path.join(srcDir, 'subDir'));
+        await fs.writeFile(path.join(srcDir, 'subDir', 'nested.txt'), 'nested');
+    });
+
+    afterAll(async () => {
+        testDataHandler.dispose();
+    });
+
+    it('copies only files, not subdirectories', () => {
+        fsUtils.copyFilesOnly(srcDir, destDir);
+        expect(fsUtils.readTextFile(path.join(destDir, 'file1.txt'))).toBe('text1');
+        expect(fsUtils.readTextFile(path.join(destDir, 'file2.txt'))).toBe('text2');
+        expect(fsUtils.fileExists(path.join(destDir, 'subDir'))).toBe(false);
+    });
+
+    it('does nothing when src does not exist', () => {
+        expect(() => fsUtils.copyFilesOnly(path.join(tempDir, 'nonexistent'), destDir)).not.toThrow();
+    });
+});
+
 describe('fsUtils', () => {
 
     it('should handle undefined filename', () => {

--- a/src/utils/fs-utils.test.ts
+++ b/src/utils/fs-utils.test.ts
@@ -110,6 +110,40 @@ describe('copyFilesOnly', () => {
     });
 });
 
+describe('copyFolderRecursiveDeferred', () => {
+    const testDataHandler = new TestDataHandler();
+    const tempDir = testDataHandler.tmpDir;
+    const srcDir = path.join(tempDir, 'deferredSrc');
+    const destDir = path.join(tempDir, 'deferredDest');
+
+    beforeAll(async () => {
+        await fs.mkdir(srcDir);
+        await fs.writeFile(path.join(srcDir, 'Blank.cproject.yml'), 'cproject');
+        await fs.writeFile(path.join(srcDir, 'main.c'), 'main');
+        await fs.writeFile(path.join(srcDir, 'Blank.csolution.yml'), 'csolution');
+        await fs.mkdir(path.join(srcDir, 'sub'));
+        await fs.writeFile(path.join(srcDir, 'sub', 'Sub.cproject.yml'), 'sub_cproject');
+        await fs.writeFile(path.join(srcDir, 'sub', 'Sub.csolution.yml'), 'sub_csolution');
+    });
+
+    afterAll(async () => {
+        testDataHandler.dispose();
+    });
+
+    it('copies all files to destination including deferred', () => {
+        fsUtils.copyFolderRecursiveDeferred(srcDir, destDir, '.csolution.yml');
+        expect(fsUtils.readTextFile(path.join(destDir, 'Blank.cproject.yml'))).toBe('cproject');
+        expect(fsUtils.readTextFile(path.join(destDir, 'main.c'))).toBe('main');
+        expect(fsUtils.readTextFile(path.join(destDir, 'Blank.csolution.yml'))).toBe('csolution');
+        expect(fsUtils.readTextFile(path.join(destDir, 'sub', 'Sub.cproject.yml'))).toBe('sub_cproject');
+        expect(fsUtils.readTextFile(path.join(destDir, 'sub', 'Sub.csolution.yml'))).toBe('sub_csolution');
+    });
+
+    it('throws when src does not exist', () => {
+        expect(() => fsUtils.copyFolderRecursiveDeferred(path.join(tempDir, 'nonexistent'), destDir, '.csolution.yml')).toThrow();
+    });
+});
+
 describe('fsUtils', () => {
 
     it('should handle undefined filename', () => {

--- a/src/utils/fs-utils.ts
+++ b/src/utils/fs-utils.ts
@@ -56,6 +56,27 @@ export function copyFolderRecursive(src: string, dest: string) {
     }
 }
 
+/**
+ * Copies only the immediate files (not subdirectories) from src to dest.
+ * Used to copy shared template files that live in a parent folder alongside
+ * device-specific solution subfolders (e.g. Blank.cproject.yml, main.c),
+ * ensuring they exist on disk before the .csolution.yml is written.
+ */
+export function copyFilesOnly(src: string, dest: string) {
+    if (!fs.existsSync(src) || !fs.statSync(src).isDirectory()) {
+        return;
+    }
+    fs.mkdirSync(dest, { recursive: true });
+    fs.readdirSync(src).forEach((item) => {
+        const srcItem = path.join(src, item);
+        const destItem = path.join(dest, item);
+        if (fs.statSync(srcItem).isFile()) {
+            fs.copyFileSync(srcItem, destItem);
+            removeReadOnly(destItem);
+        }
+    });
+}
+
 export function writeTextFile(filePath?: string, data?: string) {
     if (!filePath) {
         return;

--- a/src/utils/fs-utils.ts
+++ b/src/utils/fs-utils.ts
@@ -77,6 +77,33 @@ export function copyFilesOnly(src: string, dest: string) {
     });
 }
 
+export function copyFolderRecursiveDeferred(src: string, dest: string, deferSuffix: string) {
+    if (!fs.existsSync(src)) {
+        throw new Error(`Could not find folder to copy ${src}`);
+    }
+    const deferred: Array<{ from: string; to: string }> = [];
+    collectAndCopy(src, dest, deferSuffix, deferred);
+    for (const { from, to } of deferred) {
+        fs.copyFileSync(from, to);
+        removeReadOnly(to);
+    }
+}
+
+function collectAndCopy(src: string, dest: string, deferSuffix: string, deferred: Array<{ from: string; to: string }>) {
+    if (fs.statSync(src).isDirectory()) {
+        fs.mkdirSync(dest, { recursive: true });
+        removeReadOnly(dest);
+        fs.readdirSync(src).forEach((item) => {
+            collectAndCopy(path.join(src, item), path.join(dest, item), deferSuffix, deferred);
+        });
+    } else if (path.basename(src).endsWith(deferSuffix)) {
+        deferred.push({ from: src, to: dest });
+    } else {
+        fs.copyFileSync(src, dest);
+        removeReadOnly(dest);
+    }
+}
+
 export function writeTextFile(filePath?: string, data?: string) {
     if (!filePath) {
         return;

--- a/src/views/create-solutions/create-solution-webview-main.test.ts
+++ b/src/views/create-solutions/create-solution-webview-main.test.ts
@@ -214,9 +214,9 @@ describe('CreateSolutionWebviewMain', () => {
 
         await waitTimeout();
 
-        expect(mockFsCopyFile).toHaveBeenNthCalledWith(1, path.resolve(__dirname, '..', '..', '..', 'templates', 'template.csolution.yml'), solutionPath, expect.any(Function));
-        expect(mockFsCopyFile).toHaveBeenNthCalledWith(2, path.resolve(__dirname, '..', '..', '..', 'templates', 'template.cproject.yml'), projectPath, expect.any(Function));
-        expect(mockFsCopyFile).toHaveBeenNthCalledWith(3, path.resolve(__dirname, '..', '..', '..', 'templates', 'c', 'main.c'), cPath, expect.any(Function));
+        expect(mockFsCopyFile).toHaveBeenNthCalledWith(1, path.resolve(__dirname, '..', '..', '..', 'templates', 'template.cproject.yml'), projectPath, expect.any(Function));
+        expect(mockFsCopyFile).toHaveBeenNthCalledWith(2, path.resolve(__dirname, '..', '..', '..', 'templates', 'c', 'main.c'), cPath, expect.any(Function));
+        expect(mockFsCopyFile).toHaveBeenNthCalledWith(3, path.resolve(__dirname, '..', '..', '..', 'templates', 'template.csolution.yml'), solutionPath, expect.any(Function));
     });
 
     it('sends an error event if creation fails', async () => {


### PR DESCRIPTION
Fixes a race condition in `createFiles()` where the `.csolution.yml` file is written to disk **before** the `.cproject.yml` files it references.

The VS Code file watcher triggers `ConvertSolution` as soon as a `.csolution.yml` appears on disk. Previously, `createFiles()` wrote the csolution before the cproject files - causing the RPC to fail with
```
csolution error: cproject file was not found
csolution error: cproject not parsed, adding context failed
```

## Root Cause
The VS Code file watcher fires `ConvertSolution` as soon as a `.csolution.yml` appears on disk. If referenced `.cproject.yml` files don't exist yet, the csolution RPC binary reports the errors above.

Two code paths are affected:
**1. Built-in template path** (`createFiles()` in `solution-creator.ts`) - The `.csolution.yml` was written before the .cproject.yml` files, creating a window where the watcher fires on an incomplete project.

**2. DFP template path** (`CsolutionTemplateData.copyTo()` in `draft-project-data.ts`) - Vendor DFP packs (e.g. `Microchip::SAMD11_DFP`) structure their templates with the `.csolution.yml` inside a device-specific subfolder referencing shared files (e.g. `../Blank.cproject.yml`) at the parent level. Vendor packs have **no guaranteed file write order** - any file in the template folder may appear on disk before or after the `.csolution.yml`. The extension must enforce the correct write order regardless of how the vendor structures their template.

Move the csolution `copyFile` to after the `Promise.all` that writes all cproject and main.c files, ensuring every reference resolves when the watcher fires.

## Fix
- **`solution-creator.ts`**: Move the csolution `copyFile` to after the `Promise.all` that writes all `.cproject.yml` and `main.c` files.
- **`draft-project-data.ts`**: In `CsolutionTemplateData.copyTo()`, call `copyFilesOnly()` on the parent directory first before `copyFolderRecursive()` on the device subfolder, ensuring all referenced files exist when the `.csolution.yml` hits disk and the file watcher fires.
- **`fs-utils.ts`**: Add `copyFilesOnly()` utility - copies only immediate files (not subdirectories) from a source directory to a destination.

## Fixes
- Fixes #313
- Likely fixes #310 (same race affects TrustZone multi-project creation)

## Changes
- `src/solutions/solution-creator.ts` - write csolution last in `createFiles()`
- `src/data-manager/draft-project-data.ts` - copy parent-level files before subfolder in `copyTo()`
- `src/utils/fs-utils.ts` - add `copyFilesOnly()` helper