### PR TITLE
Artifact upload of vsix files without zipping

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,6 +183,7 @@ jobs:
           name: vscode-cmsis-solution-win32-x64
           path: ./*win32-x64*.vsix
           retention-days: 1
+          archive: false
 
       - name: Upload win32-arm64 VSIX package
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -190,6 +191,7 @@ jobs:
           name: vscode-cmsis-solution-win32-arm64
           path: ./*win32-arm64*.vsix
           retention-days: 1
+          archive: false
 
       - name: Upload linux-x64 VSIX package
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -197,6 +199,7 @@ jobs:
           name: vscode-cmsis-solution-linux-x64
           path: ./*linux-x64*.vsix
           retention-days: 1
+          archive: false
 
       - name: Upload linux-arm64 VSIX package
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -204,6 +207,7 @@ jobs:
           name: vscode-cmsis-solution-linux-arm64
           path: ./*linux-arm64*.vsix
           retention-days: 1
+          archive: false
 
       - name: Upload darwin-x64 VSIX package
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -211,6 +215,7 @@ jobs:
           name: vscode-cmsis-solution-darwin-x64
           path: ./*darwin-x64*.vsix
           retention-days: 1
+          archive: false
 
       - name: Upload darwin-arm64 VSIX package
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -218,6 +223,7 @@ jobs:
           name: vscode-cmsis-solution-darwin-arm64
           path: ./*darwin-arm64*.vsix
           retention-days: 1
+          archive: false
 
       - name: Create version bump patch
         run: git diff > new-version.patch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,7 +180,6 @@ jobs:
       - name: Upload win32-x64 VSIX package
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: vscode-cmsis-solution-win32-x64
           path: ./*win32-x64*.vsix
           retention-days: 1
           archive: false
@@ -188,7 +187,6 @@ jobs:
       - name: Upload win32-arm64 VSIX package
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: vscode-cmsis-solution-win32-arm64
           path: ./*win32-arm64*.vsix
           retention-days: 1
           archive: false
@@ -196,7 +194,6 @@ jobs:
       - name: Upload linux-x64 VSIX package
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: vscode-cmsis-solution-linux-x64
           path: ./*linux-x64*.vsix
           retention-days: 1
           archive: false
@@ -204,7 +201,6 @@ jobs:
       - name: Upload linux-arm64 VSIX package
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: vscode-cmsis-solution-linux-arm64
           path: ./*linux-arm64*.vsix
           retention-days: 1
           archive: false
@@ -212,7 +208,6 @@ jobs:
       - name: Upload darwin-x64 VSIX package
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: vscode-cmsis-solution-darwin-x64
           path: ./*darwin-x64*.vsix
           retention-days: 1
           archive: false
@@ -220,7 +215,6 @@ jobs:
       - name: Upload darwin-arm64 VSIX package
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: vscode-cmsis-solution-darwin-arm64
           path: ./*darwin-arm64*.vsix
           retention-days: 1
           archive: false
@@ -316,7 +310,7 @@ jobs:
       - name: Download packages
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          pattern: vscode-cmsis-solution-*
+          pattern: cmsis-solution-*.vsix
 
       - name: Download coverage report
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -112,6 +112,7 @@ jobs:
 
           # Update package.json
           npm version "${NIGHTLY_VERSION}" --no-git-tag-version
+          echo "NIGHTLY_VERSION=${NIGHTLY_VERSION}" >> "$GITHUB_ENV"
 
       - name: Remove badges
         run: |
@@ -130,7 +131,7 @@ jobs:
         run: ./download-tools.sh win32-x64
 
       - name: Package win32-x64
-        run: npm run package -- --target win32-x64
+        run: npm run package -- --target win32-x64 --out "cmsis-csolution-nightly-win32-x64-${NIGHTLY_VERSION}.vsix"
 
       - name: Download dependencies (win32-arm64)
         working-directory: .github/workflows
@@ -139,7 +140,7 @@ jobs:
         run: ./download-tools.sh win32-arm64
 
       - name: Package win32-arm64
-        run: npm run package -- --target win32-arm64
+        run: npm run package -- --target win32-arm64 --out "cmsis-csolution-nightly-win32-arm64-${NIGHTLY_VERSION}.vsix"
 
       - name: Download dependencies (linux-x64)
         working-directory: .github/workflows
@@ -148,7 +149,7 @@ jobs:
         run: ./download-tools.sh linux-x64
 
       - name: Package linux-x64
-        run: npm run package -- --target linux-x64
+        run: npm run package -- --target linux-x64 --out "cmsis-csolution-nightly-linux-x64-${NIGHTLY_VERSION}.vsix"
 
       - name: Download dependencies (linux-arm64)
         working-directory: .github/workflows
@@ -157,7 +158,7 @@ jobs:
         run: ./download-tools.sh linux-arm64
 
       - name: Package linux-arm64
-        run: npm run package -- --target linux-arm64
+        run: npm run package -- --target linux-arm64 --out "cmsis-csolution-nightly-linux-arm64-${NIGHTLY_VERSION}.vsix"
 
       - name: Download dependencies (darwin-x64)
         working-directory: .github/workflows
@@ -166,7 +167,7 @@ jobs:
         run: ./download-tools.sh darwin-x64
 
       - name: Package darwin-x64
-        run: npm run package -- --target darwin-x64
+        run: npm run package -- --target darwin-x64 --out "cmsis-csolution-nightly-darwin-x64-${NIGHTLY_VERSION}.vsix"
 
       - name: Download dependencies (darwin-arm64)
         working-directory: .github/workflows
@@ -175,49 +176,49 @@ jobs:
         run: ./download-tools.sh darwin-arm64
 
       - name: Package darwin-arm64
-        run: npm run package -- --target darwin-arm64
+        run: npm run package -- --target darwin-arm64 --out "cmsis-csolution-nightly-darwin-arm64-${NIGHTLY_VERSION}.vsix"
 
       - name: Upload win32-x64 VSIX package
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: vscode-cmsis-solution-nightly-win32-x64
           path: ./*win32-x64*.vsix
           retention-days: 1
+          archive: false
 
       - name: Upload win32-arm64 VSIX package
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: vscode-cmsis-solution-nightly-win32-arm64
           path: ./*win32-arm64*.vsix
           retention-days: 1
+          archive: false
 
       - name: Upload linux-x64 VSIX package
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: vscode-cmsis-solution-nightly-linux-x64
           path: ./*linux-x64*.vsix
           retention-days: 1
+          archive: false
 
       - name: Upload linux-arm64 VSIX package
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: vscode-cmsis-solution-nightly-linux-arm64
           path: ./*linux-arm64*.vsix
           retention-days: 1
+          archive: false
 
       - name: Upload darwin-x64 VSIX package
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: vscode-cmsis-solution-nightly-darwin-x64
           path: ./*darwin-x64*.vsix
           retention-days: 1
+          archive: false
 
       - name: Upload darwin-arm64 VSIX package
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: vscode-cmsis-solution-nightly-darwin-arm64
           path: ./*darwin-arm64*.vsix
           retention-days: 1
+          archive: false
 
   test:
     name: 'Test (windows-latest)'
@@ -261,7 +262,7 @@ jobs:
       - name: Download VSIX package
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: vscode-cmsis-solution-nightly-win32-x64
+          name: cmsis-csolution-nightly-win32-x64-*.vsix
 
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -300,6 +301,7 @@ jobs:
         with:
           name: e2e-report
           path: e2e-report
+          archive: false
 
       - name: Upload Screenshots
         if: always() && steps.tests.conclusion != 'skipped'
@@ -307,3 +309,4 @@ jobs:
         with:
           name: e2e-screenshots
           path: e2e-screenshots
+          archive: false

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -301,7 +301,6 @@ jobs:
         with:
           name: e2e-report
           path: e2e-report
-          archive: false
 
       - name: Upload Screenshots
         if: always() && steps.tests.conclusion != 'skipped'
@@ -309,4 +308,3 @@ jobs:
         with:
           name: e2e-screenshots
           path: e2e-screenshots
-          archive: false

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -112,6 +112,7 @@ jobs:
 
           # Update package.json
           npm version "${NIGHTLY_VERSION}" --no-git-tag-version
+          echo "NIGHTLY_VERSION=${NIGHTLY_VERSION}" >> "$GITHUB_ENV"
 
       - name: Remove badges
         run: |
@@ -130,7 +131,7 @@ jobs:
         run: ./download-tools.sh win32-x64
 
       - name: Package win32-x64
-        run: npm run package -- --target win32-x64
+        run: npm run package -- --target win32-x64 --out "cmsis-csolution-nightly-win32-x64-${NIGHTLY_VERSION}.vsix"
 
       - name: Download dependencies (win32-arm64)
         working-directory: .github/workflows
@@ -139,7 +140,7 @@ jobs:
         run: ./download-tools.sh win32-arm64
 
       - name: Package win32-arm64
-        run: npm run package -- --target win32-arm64
+        run: npm run package -- --target win32-arm64 --out "cmsis-csolution-nightly-win32-arm64-${NIGHTLY_VERSION}.vsix"
 
       - name: Download dependencies (linux-x64)
         working-directory: .github/workflows
@@ -148,7 +149,7 @@ jobs:
         run: ./download-tools.sh linux-x64
 
       - name: Package linux-x64
-        run: npm run package -- --target linux-x64
+        run: npm run package -- --target linux-x64 --out "cmsis-csolution-nightly-linux-x64-${NIGHTLY_VERSION}.vsix"
 
       - name: Download dependencies (linux-arm64)
         working-directory: .github/workflows
@@ -157,7 +158,7 @@ jobs:
         run: ./download-tools.sh linux-arm64
 
       - name: Package linux-arm64
-        run: npm run package -- --target linux-arm64
+        run: npm run package -- --target linux-arm64 --out "cmsis-csolution-nightly-linux-arm64-${NIGHTLY_VERSION}.vsix"
 
       - name: Download dependencies (darwin-x64)
         working-directory: .github/workflows
@@ -166,7 +167,7 @@ jobs:
         run: ./download-tools.sh darwin-x64
 
       - name: Package darwin-x64
-        run: npm run package -- --target darwin-x64
+        run: npm run package -- --target darwin-x64 --out "cmsis-csolution-nightly-darwin-x64-${NIGHTLY_VERSION}.vsix"
 
       - name: Download dependencies (darwin-arm64)
         working-directory: .github/workflows
@@ -175,49 +176,49 @@ jobs:
         run: ./download-tools.sh darwin-arm64
 
       - name: Package darwin-arm64
-        run: npm run package -- --target darwin-arm64
+        run: npm run package -- --target darwin-arm64 --out "cmsis-csolution-nightly-darwin-arm64-${NIGHTLY_VERSION}.vsix"
 
       - name: Upload win32-x64 VSIX package
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: vscode-cmsis-solution-nightly-win32-x64
           path: ./*win32-x64*.vsix
           retention-days: 1
+          archive: false
 
       - name: Upload win32-arm64 VSIX package
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: vscode-cmsis-solution-nightly-win32-arm64
           path: ./*win32-arm64*.vsix
           retention-days: 1
+          archive: false
 
       - name: Upload linux-x64 VSIX package
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: vscode-cmsis-solution-nightly-linux-x64
           path: ./*linux-x64*.vsix
           retention-days: 1
+          archive: false
 
       - name: Upload linux-arm64 VSIX package
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: vscode-cmsis-solution-nightly-linux-arm64
           path: ./*linux-arm64*.vsix
           retention-days: 1
+          archive: false
 
       - name: Upload darwin-x64 VSIX package
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: vscode-cmsis-solution-nightly-darwin-x64
           path: ./*darwin-x64*.vsix
           retention-days: 1
+          archive: false
 
       - name: Upload darwin-arm64 VSIX package
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: vscode-cmsis-solution-nightly-darwin-arm64
           path: ./*darwin-arm64*.vsix
           retention-days: 1
+          archive: false
 
   test:
     name: 'Test (windows-latest)'
@@ -261,7 +262,7 @@ jobs:
       - name: Download VSIX package
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: vscode-cmsis-solution-nightly-win32-x64
+          pattern: cmsis-csolution-nightly-win32-x64-*.vsix
 
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -300,6 +301,7 @@ jobs:
         with:
           name: e2e-report
           path: e2e-report
+          archive: false
 
       - name: Upload Screenshots
         if: always() && steps.tests.conclusion != 'skipped'
@@ -307,3 +309,4 @@ jobs:
         with:
           name: e2e-screenshots
           path: e2e-screenshots
+          archive: false


### PR DESCRIPTION
## Changes

- upload artifacts of VSCode extension VSIX files without additional/unnecessary archiving by setting `archive: false`
- Removed name property from upload action as they become redundant and ignored when the artifact uploaded is a file.

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [x] 🤖 This change is covered by unit tests (if applicable).
- [x] 🤹 Manual testing has been performed (if necessary).
- [x] 🛡️ Security impacts have been considered (if relevant).
- [x] 📖 Documentation updates are complete (if required).
- [x] 🧠 Third-party dependencies and TPIP updated (if required).
