### PR TITLE
Gracefully handle missing `pack.idx` file

### DIFF
--- a/src/json-rpc/csolution-rpc-client.ts
+++ b/src/json-rpc/csolution-rpc-client.ts
@@ -129,20 +129,24 @@ class CsolutionServiceImpl extends RpcMethods implements CsolutionService {
     private watchPackIdxFile() {
         this.idxWatcher?.close();
         const pack_idx = path.join(getCmsisPackRoot(), 'pack.idx');
-        let mtimeMs = fs.statSync(pack_idx)?.mtimeMs;
-        this.idxWatcher = fs.watch(pack_idx, eventType => {
-            if (eventType === 'change') {
-                const stat = fs.statSync(pack_idx);
-                if (stat?.mtimeMs !== mtimeMs) {
-                    mtimeMs = stat.mtimeMs;
-                    if (this.packIdxWatcherSuspendDepth > 0) {
-                        this.pendingPackIdxChange = true;
-                        return;
+        try {
+            let mtimeMs = fs.statSync(pack_idx)?.mtimeMs;
+            this.idxWatcher = fs.watch(pack_idx, eventType => {
+                if (eventType === 'change') {
+                    const stat = fs.statSync(pack_idx);
+                    if (stat?.mtimeMs !== mtimeMs) {
+                        mtimeMs = stat.mtimeMs;
+                        if (this.packIdxWatcherSuspendDepth > 0) {
+                            this.pendingPackIdxChange = true;
+                            return;
+                        }
+                        this.debouncedLoadPacks();
                     }
-                    this.debouncedLoadPacks();
                 }
-            }
-        });
+            });
+        } catch (error) {
+            // pack.idx may not exist yet, gracefully handle the error
+        }
     }
 
     private async transceive<TResponse>(method: string, params?: unknown, ..._rest: unknown[]):

--- a/src/json-rpc/csolution-rpc-client.ts
+++ b/src/json-rpc/csolution-rpc-client.ts
@@ -128,6 +128,7 @@ class CsolutionServiceImpl extends RpcMethods implements CsolutionService {
 
     private watchPackIdxFile() {
         this.idxWatcher?.close();
+        this.idxWatcher = undefined;
         const pack_idx = path.join(getCmsisPackRoot(), 'pack.idx');
         try {
             let mtimeMs = fs.statSync(pack_idx)?.mtimeMs;
@@ -145,7 +146,11 @@ class CsolutionServiceImpl extends RpcMethods implements CsolutionService {
                 }
             });
         } catch (error) {
-            // pack.idx may not exist yet, gracefully handle the error
+            if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+                // pack.idx may not exist yet, gracefully handle the error
+            } else {
+                console.warn('Failed to watch pack.idx file:', error);
+            }
         }
     }
 

--- a/src/json-rpc/csolution-rpc-helper.test.ts
+++ b/src/json-rpc/csolution-rpc-helper.test.ts
@@ -502,7 +502,6 @@ describe('csolution-rpc-client', () => {
         });
 
         it('logs non-ENOENT errors and leaves watcher undefined', () => {
-            const packIdx = path.join('/cmsis-packs', 'pack.idx');
             const permError = new Error('EACCES: permission denied');
             (permError as any).code = 'EACCES';
 

--- a/src/json-rpc/csolution-rpc-helper.test.ts
+++ b/src/json-rpc/csolution-rpc-helper.test.ts
@@ -477,6 +477,28 @@ describe('csolution-rpc-client', () => {
             expect(service.pendingPackIdxChange).toBe(false);
             expect(service.packIdxWatcherSuspendDepth).toBe(0);
         });
+
+        it('gracefully handles missing pack.idx file', () => {
+            const packIdx = path.join('/cmsis-packs', 'pack.idx');
+            const error = new Error('ENOENT: no such file or directory');
+            (error as any).code = 'ENOENT';
+
+            (fs.statSync as unknown as jest.Mock).mockImplementation(() => {
+                throw error;
+            });
+            (fs.watch as unknown as jest.Mock).mockImplementation((_file: string, _listener: any) => ({ close: jest.fn() }));
+
+            // Should not throw
+            expect(() => service.watchPackIdxFile()).not.toThrow();
+
+            // Should still attempt to get pack root and call statSync
+            expect(pathUtils.getCmsisPackRoot).toHaveBeenCalledTimes(1);
+            expect(fs.statSync).toHaveBeenCalledWith(packIdx);
+
+            // fs.watch should not be set up since statSync failed
+            expect(fs.watch).not.toHaveBeenCalled();
+            expect(service.idxWatcher).toBeUndefined();
+        });
     });
 
     describe('csolution-rpc-client launch', () => {

--- a/src/json-rpc/csolution-rpc-helper.test.ts
+++ b/src/json-rpc/csolution-rpc-helper.test.ts
@@ -498,6 +498,43 @@ describe('csolution-rpc-client', () => {
             // fs.watch should not be set up since statSync failed
             expect(fs.watch).not.toHaveBeenCalled();
             expect(service.idxWatcher).toBeUndefined();
+            expect(console.warn).not.toHaveBeenCalled();
+        });
+
+        it('logs non-ENOENT errors and leaves watcher undefined', () => {
+            const packIdx = path.join('/cmsis-packs', 'pack.idx');
+            const permError = new Error('EACCES: permission denied');
+            (permError as any).code = 'EACCES';
+
+            (fs.statSync as unknown as jest.Mock).mockImplementation(() => {
+                throw permError;
+            });
+            (fs.watch as unknown as jest.Mock).mockImplementation((_file: string, _listener: any) => ({ close: jest.fn() }));
+
+            // Should not throw
+            expect(() => service.watchPackIdxFile()).not.toThrow();
+
+            // Should log the error
+            expect(console.warn).toHaveBeenCalledWith('Failed to watch pack.idx file:', permError);
+
+            // fs.watch should not be set up
+            expect(fs.watch).not.toHaveBeenCalled();
+            expect(service.idxWatcher).toBeUndefined();
+        });
+
+        it('resets idxWatcher to undefined after closing existing watcher', () => {
+            const prevClose = jest.fn();
+            service.idxWatcher = { close: prevClose };
+
+            (fs.statSync as unknown as jest.Mock).mockReturnValue({ mtimeMs: 1 });
+            (fs.watch as unknown as jest.Mock).mockImplementation((_file: string, _listener: any) => ({ close: jest.fn() }));
+
+            service.watchPackIdxFile();
+
+            expect(prevClose).toHaveBeenCalledTimes(1);
+            // idxWatcher should be set to the new watcher, not undefined
+            expect(service.idxWatcher).toBeDefined();
+            expect(service.idxWatcher.close).not.toBe(prevClose);
         });
     });
 


### PR DESCRIPTION
## Fixes
<!-- List the GitHub issue(s) this PR resolves (e.g. #123) -->
- https://github.com/Open-CMSIS-Pack/vscode-cmsis-solution/actions/runs/27817311103/job/82322513319?pr=325
```
2026-06-19T09:38:29.5605433Z Playwright (Electron): window.on('console.error') [[Arm.cmsis-csolution]ENOENT: no such file or directory, stat 'C:\Users\runneradmin\AppData\Local\arm\packs\pack.idx']
2026-06-19T09:38:29.5608064Z Playwright (Electron): window.on('console.error') [Error: ENOENT: no such file or directory, stat 'C:\Users\runneradmin\AppData\Local\arm\packs\pack.idx'
```

## Changes
<!-- List the changes this PR introduces -->
- Wrapped the `pack.idx` file stat and watch initialization in a try-catch block to gracefully handle the case when the file doesn't exist.
- The watcher setup is now skipped if the file is missing, preventing console errors during extension startup.

## Screenshots
<!-- Show UI changes with screenshots to ease UX/UI feedback: -->

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [x] 🤖 This change is covered by unit tests (if applicable).
- [x] 🤹 Manual testing has been performed (if necessary).
- [x] 🛡️ Security impacts have been considered (if relevant).
- [x] 📖 Documentation updates are complete (if required).
- [x] 🧠 Third-party dependencies and TPIP updated (if required).
