### PR TITLE
Refresh outline view for West Projects after cbuild setup complete

### DIFF
--- a/src/solutions/csolution.test.ts
+++ b/src/solutions/csolution.test.ts
@@ -21,6 +21,7 @@ import { CSolution } from './csolution';
 import { ETextFileResult } from '../generic/text-file';
 import { CTreeItem } from '../generic/tree-item';
 import { parseYamlToCTreeItem } from '../generic/tree-item-yaml-parser';
+import { CProjectYamlFile } from './files/cproject-yaml-file';
 
 describe('CSolution', () => {
     const testDataHandler = new TestDataHandler();
@@ -619,6 +620,37 @@ describe('CSolution', () => {
 
                 expect(csolution.getDefaultTargetTypeItem).toHaveBeenCalled();
             });
+        });
+    });
+
+    describe('hasWestProject', () => {
+        let csolution: CSolution;
+
+        beforeEach(() => {
+            csolution = new CSolution();
+            csolution.projects.clear();
+        });
+
+        it('returns true when at least one project is West', () => {
+            const westProject = { projectType: 'West' } as CProjectYamlFile;
+            const regularProject = { projectType: 'library' } as CProjectYamlFile;
+            csolution.projects.set('west', westProject);
+            csolution.projects.set('lib', regularProject);
+
+            expect(csolution.hasWestProject()).toBe(true);
+        });
+
+        it('returns false when no projects are West', () => {
+            const libProject = { projectType: 'library' } as CProjectYamlFile;
+            const exeProject = { projectType: 'executable' } as CProjectYamlFile;
+            csolution.projects.set('lib', libProject);
+            csolution.projects.set('exe', exeProject);
+
+            expect(csolution.hasWestProject()).toBe(false);
+        });
+
+        it('returns false when there are no projects', () => {
+            expect(csolution.hasWestProject()).toBe(false);
         });
     });
 });

--- a/src/solutions/csolution.ts
+++ b/src/solutions/csolution.ts
@@ -471,6 +471,16 @@ export class CSolution {
         return this.csolutionYml.compilers;
     }
 
+    public hasWestProject(): boolean {
+        for (const project of this.projects.values()) {
+            if (project?.projectType === 'West') {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
 };
 
 export function expandPath(path: string, csolution?: CSolution, targetType?: string,): string {

--- a/src/views/solution-outline/solution-outline.test.ts
+++ b/src/views/solution-outline/solution-outline.test.ts
@@ -273,13 +273,14 @@ describe('SolutionOutlineView', () => {
 
     });
 
-    it('refreshes the tree on setup completion when a West project exists', async () => {
+    it('refreshes the tree on compilation database update when a West project exists', async () => {
         const solutionLoadedState = activeSolutionLoadStateFactory();
         const westProject = { projectType: 'West' } as unknown as CProjectYamlFile;
         const mockCsolution = csolutionFactory({
             projects: new Map<string, CProjectYamlFile>([['westProject', westProject]]),
         });
         mockCsolution.hasWestProject = jest.fn().mockReturnValue(true);
+        mockCsolution.loadBuildFiles = jest.fn().mockResolvedValue(1 as any);
         const mockSolutionManager = solutionManagerFactory({
             loadState: solutionLoadedState,
             getCsolution: jest.fn().mockReturnValue(mockCsolution),
@@ -293,9 +294,10 @@ describe('SolutionOutlineView', () => {
         );
         await view.activate(extensionContextFactory());
 
-        mockSolutionManager.onDidSetupCompletedEmitter.fire(['success', false]);
+        mockSolutionManager.onUpdatedCompileCommandsEmitter.fire();
         await waitForPromises();
 
+        expect(mockCsolution.loadBuildFiles).toHaveBeenCalled();
         expect(mockTreeViewProvider.updateTree).toHaveBeenCalled();
     });
 

--- a/src/views/solution-outline/solution-outline.test.ts
+++ b/src/views/solution-outline/solution-outline.test.ts
@@ -25,7 +25,6 @@ import { CsolutionGlobalState, GlobalState } from '../../vscode-api/global-state
 import { globalStateFactory } from '../../vscode-api/global-state.factories';
 import { COutlineItem } from './tree-structure/solution-outline-item';
 import { csolutionFactory } from '../../solutions/csolution.factory';
-import { CProjectYamlFile } from '../../solutions/files/cproject-yaml-file';
 import { TreeViewFileDecorationProvider } from './treeview-decoration-provider';
 import { configurationProviderFactory, MockConfigurationProvider } from '../../vscode-api/configuration-provider.factories';
 import { CONFIG_AUTO_SHOW_CMSIS_VIEW } from '../../manifest';
@@ -275,16 +274,14 @@ describe('SolutionOutlineView', () => {
 
     it('refreshes the tree on compilation database update when a West project exists', async () => {
         const solutionLoadedState = activeSolutionLoadStateFactory();
-        const westProject = { projectType: 'West' } as unknown as CProjectYamlFile;
-        const mockCsolution = csolutionFactory({
-            projects: new Map<string, CProjectYamlFile>([['westProject', westProject]]),
-        });
+        const mockCsolution = csolutionFactory();
         mockCsolution.hasWestProject = jest.fn().mockReturnValue(true);
-        mockCsolution.loadBuildFiles = jest.fn().mockResolvedValue(1 as any);
+
         const mockSolutionManager = solutionManagerFactory({
             loadState: solutionLoadedState,
             getCsolution: jest.fn().mockReturnValue(mockCsolution),
         });
+
         const view = new SolutionOutlineView(
             mockSolutionManager,
             mockTreeViewProvider,
@@ -292,26 +289,24 @@ describe('SolutionOutlineView', () => {
             mockTreeViewFileDecorationProvider,
             configurationProvider
         );
-        await view.activate(extensionContextFactory());
 
+        await view.activate(extensionContextFactory());
         mockSolutionManager.onUpdatedCompileCommandsEmitter.fire();
         await waitForPromises();
 
-        expect(mockCsolution.loadBuildFiles).toHaveBeenCalled();
         expect(mockTreeViewProvider.updateTree).toHaveBeenCalled();
     });
 
     it('does not refresh the tree on compilation database update when no West project exists', async () => {
         const solutionLoadedState = activeSolutionLoadStateFactory();
-        const mockCsolution = csolutionFactory({
-            projects: new Map<string, CProjectYamlFile>(),
-        });
+        const mockCsolution = csolutionFactory();
         mockCsolution.hasWestProject = jest.fn().mockReturnValue(false);
-        mockCsolution.loadBuildFiles = jest.fn().mockResolvedValue(1 as any);
+
         const mockSolutionManager = solutionManagerFactory({
             loadState: solutionLoadedState,
             getCsolution: jest.fn().mockReturnValue(mockCsolution),
         });
+
         const view = new SolutionOutlineView(
             mockSolutionManager,
             mockTreeViewProvider,
@@ -319,9 +314,12 @@ describe('SolutionOutlineView', () => {
             mockTreeViewFileDecorationProvider,
             configurationProvider
         );
+
         await view.activate(extensionContextFactory());
 
+        // Reset the mock to ensure it wasn't called during activation
         (mockTreeViewProvider.updateTree as jest.Mock).mockClear();
+
         mockSolutionManager.onUpdatedCompileCommandsEmitter.fire();
         await waitForPromises();
 

--- a/src/views/solution-outline/solution-outline.test.ts
+++ b/src/views/solution-outline/solution-outline.test.ts
@@ -25,6 +25,7 @@ import { CsolutionGlobalState, GlobalState } from '../../vscode-api/global-state
 import { globalStateFactory } from '../../vscode-api/global-state.factories';
 import { COutlineItem } from './tree-structure/solution-outline-item';
 import { csolutionFactory } from '../../solutions/csolution.factory';
+import { CProjectYamlFile } from '../../solutions/files/cproject-yaml-file';
 import { TreeViewFileDecorationProvider } from './treeview-decoration-provider';
 import { configurationProviderFactory, MockConfigurationProvider } from '../../vscode-api/configuration-provider.factories';
 import { CONFIG_AUTO_SHOW_CMSIS_VIEW } from '../../manifest';
@@ -35,6 +36,7 @@ describe('SolutionOutlineView', () => {
     let visibilityChangeEmitter: vscode.EventEmitter<Event>;
     let globalStateProvider: GlobalState<CsolutionGlobalState>;
     let configurationProvider: MockConfigurationProvider;
+    let executeCommandSpy: jest.SpyInstance;
 
     beforeEach(async () => {
         visibilityChangeEmitter = new vscode.EventEmitter();
@@ -54,6 +56,11 @@ describe('SolutionOutlineView', () => {
 
         globalStateProvider = globalStateFactory();
         configurationProvider = configurationProviderFactory();
+        executeCommandSpy = jest.spyOn(vscode.commands, 'executeCommand').mockResolvedValue(undefined);
+    });
+
+    afterEach(() => {
+        executeCommandSpy.mockRestore();
     });
 
 
@@ -214,7 +221,6 @@ describe('SolutionOutlineView', () => {
     });
 
     it('reveals the solution outline when a new solution is loaded and auto reveal is enabled', async () => {
-        const executeCommandSpy = jest.spyOn(vscode.commands, 'executeCommand').mockResolvedValue(undefined);
         const solutionLoadedState = activeSolutionLoadStateFactory();
         const mockSolutionManager = solutionManagerFactory({
             loadState: solutionLoadedState,
@@ -237,11 +243,9 @@ describe('SolutionOutlineView', () => {
 
         expect(executeCommandSpy).toHaveBeenCalledWith(`${SolutionOutlineView.treeViewId}.open`, { preserveFocus: true });
 
-        executeCommandSpy.mockRestore();
     });
 
     it('does not reveal the solution outline when auto reveal is disabled', async () => {
-        const executeCommandSpy = jest.spyOn(vscode.commands, 'executeCommand').mockResolvedValue(undefined);
         const solutionLoadedState = activeSolutionLoadStateFactory();
         const mockSolutionManager = solutionManagerFactory({
             loadState: solutionLoadedState,
@@ -267,7 +271,58 @@ describe('SolutionOutlineView', () => {
 
         expect(executeCommandSpy).not.toHaveBeenCalledWith(`${SolutionOutlineView.treeViewId}.open`, { preserveFocus: true });
 
-        executeCommandSpy.mockRestore();
+    });
+
+    it('refreshes the tree on setup completion when a West project exists', async () => {
+        const solutionLoadedState = activeSolutionLoadStateFactory();
+        const westProject = { projectType: 'West' } as unknown as CProjectYamlFile;
+        const mockCsolution = csolutionFactory({
+            projects: new Map<string, CProjectYamlFile>([['westProject', westProject]]),
+        });
+        mockCsolution.hasWestProject = jest.fn().mockReturnValue(true);
+        const mockSolutionManager = solutionManagerFactory({
+            loadState: solutionLoadedState,
+            getCsolution: jest.fn().mockReturnValue(mockCsolution),
+        });
+        const view = new SolutionOutlineView(
+            mockSolutionManager,
+            mockTreeViewProvider,
+            globalStateProvider,
+            mockTreeViewFileDecorationProvider,
+            configurationProvider
+        );
+        await view.activate(extensionContextFactory());
+
+        mockSolutionManager.onDidSetupCompletedEmitter.fire(['success', false]);
+        await waitForPromises();
+
+        expect(mockTreeViewProvider.updateTree).toHaveBeenCalled();
+    });
+
+    it('does not refresh the tree on setup completion when no West project exists', async () => {
+        const solutionLoadedState = activeSolutionLoadStateFactory();
+        const mockCsolution = csolutionFactory({
+            projects: new Map<string, CProjectYamlFile>(),
+        });
+        mockCsolution.hasWestProject = jest.fn().mockReturnValue(false);
+        const mockSolutionManager = solutionManagerFactory({
+            loadState: solutionLoadedState,
+            getCsolution: jest.fn().mockReturnValue(mockCsolution),
+        });
+        const view = new SolutionOutlineView(
+            mockSolutionManager,
+            mockTreeViewProvider,
+            globalStateProvider,
+            mockTreeViewFileDecorationProvider,
+            configurationProvider
+        );
+        await view.activate(extensionContextFactory());
+
+        mockTreeViewProvider.updateTree = jest.fn();
+        mockSolutionManager.onDidSetupCompletedEmitter.fire(['success', false]);
+        await waitForPromises();
+
+        expect(mockTreeViewProvider.updateTree).not.toHaveBeenCalled();
     });
 
 });

--- a/src/views/solution-outline/solution-outline.test.ts
+++ b/src/views/solution-outline/solution-outline.test.ts
@@ -299,12 +299,13 @@ describe('SolutionOutlineView', () => {
         expect(mockTreeViewProvider.updateTree).toHaveBeenCalled();
     });
 
-    it('does not refresh the tree on setup completion when no West project exists', async () => {
+    it('does not refresh the tree on compilation database update when no West project exists', async () => {
         const solutionLoadedState = activeSolutionLoadStateFactory();
         const mockCsolution = csolutionFactory({
             projects: new Map<string, CProjectYamlFile>(),
         });
         mockCsolution.hasWestProject = jest.fn().mockReturnValue(false);
+        mockCsolution.loadBuildFiles = jest.fn().mockResolvedValue(1 as any);
         const mockSolutionManager = solutionManagerFactory({
             loadState: solutionLoadedState,
             getCsolution: jest.fn().mockReturnValue(mockCsolution),
@@ -318,8 +319,8 @@ describe('SolutionOutlineView', () => {
         );
         await view.activate(extensionContextFactory());
 
-        mockTreeViewProvider.updateTree = jest.fn();
-        mockSolutionManager.onDidSetupCompletedEmitter.fire(['success', false]);
+        (mockTreeViewProvider.updateTree as jest.Mock).mockClear();
+        mockSolutionManager.onUpdatedCompileCommandsEmitter.fire();
         await waitForPromises();
 
         expect(mockTreeViewProvider.updateTree).not.toHaveBeenCalled();

--- a/src/views/solution-outline/solution-outline.ts
+++ b/src/views/solution-outline/solution-outline.ts
@@ -47,7 +47,7 @@ export class SolutionOutlineView {
                 this.hasSeen();
             }),
             this.solutionManager.onDidChangeLoadState(this.handleChangeLoadState, this),
-            this.solutionManager.onDidSetupCompleted(this.handleSetupCompleted, this),
+            this.solutionManager.onUpdatedCompileCommands(this.handleUpdatedCompileCommands, this),
         );
         this.treeViewProvider.activate(context);
     }
@@ -57,11 +57,13 @@ export class SolutionOutlineView {
         this.treeViewProvider.setBadge({ tooltip: '', value: 0 });
     }
 
-    private async handleSetupCompleted() {
-        if (!this.solutionManager.getCsolution()?.hasWestProject()) {
+    private async handleUpdatedCompileCommands() {
+        const csolution = this.solutionManager.getCsolution();
+        if (!csolution?.hasWestProject()) {
             return;
         }
 
+        await csolution.loadBuildFiles();
         await this.updateTree(this.solutionManager.loadState);
     }
 

--- a/src/views/solution-outline/solution-outline.ts
+++ b/src/views/solution-outline/solution-outline.ts
@@ -47,6 +47,7 @@ export class SolutionOutlineView {
                 this.hasSeen();
             }),
             this.solutionManager.onDidChangeLoadState(this.handleChangeLoadState, this),
+            this.solutionManager.onDidSetupCompleted(this.handleSetupCompleted, this),
         );
         this.treeViewProvider.activate(context);
     }
@@ -54,6 +55,14 @@ export class SolutionOutlineView {
     public hasSeen() {
         this.globalStateProvider.update('panelSeen', true);
         this.treeViewProvider.setBadge({ tooltip: '', value: 0 });
+    }
+
+    private async handleSetupCompleted() {
+        if (!this.solutionManager.getCsolution()?.hasWestProject()) {
+            return;
+        }
+
+        await this.updateTree(this.solutionManager.loadState);
     }
 
     private async handleChangeLoadState(e: SolutionLoadStateChangeEvent) {

--- a/src/views/solution-outline/tree-structure/solution-outline-tree.test.ts
+++ b/src/views/solution-outline/tree-structure/solution-outline-tree.test.ts
@@ -83,6 +83,7 @@ describe('CSolution', () => {
 
         const loadResult = await csolution.load(fileName);
         expect(loadResult).toEqual(ETextFileResult.Success);
+        expect(csolution.hasWestProject).toBeFalsy();
 
         const cdefaultPath = csolution.cbuildIdxFile?.topItem?.getValue('cdefault');
         const hasCdefault = !!cdefaultPath && fsUtils.fileExists(
@@ -241,6 +242,7 @@ describe('CSolution', () => {
 
         const loadResult = await csolution.load(fileName);
         expect(loadResult).toEqual(ETextFileResult.Success);
+        expect(csolution.hasWestProject).toBeTruthy();
 
         // get results from tree
         const solutionOutlineTree = new SolutionOutlineTree(csolution, rpcData);

--- a/src/views/solution-outline/tree-structure/solution-outline-tree.test.ts
+++ b/src/views/solution-outline/tree-structure/solution-outline-tree.test.ts
@@ -242,7 +242,7 @@ describe('CSolution', () => {
 
         const loadResult = await csolution.load(fileName);
         expect(loadResult).toEqual(ETextFileResult.Success);
-        expect(csolution.hasWestProject).toBeTruthy();
+        expect(csolution.hasWestProject()).toBeTruthy();
 
         // get results from tree
         const solutionOutlineTree = new SolutionOutlineTree(csolution, rpcData);

--- a/src/views/solution-outline/tree-structure/solution-outline-tree.test.ts
+++ b/src/views/solution-outline/tree-structure/solution-outline-tree.test.ts
@@ -83,7 +83,7 @@ describe('CSolution', () => {
 
         const loadResult = await csolution.load(fileName);
         expect(loadResult).toEqual(ETextFileResult.Success);
-        expect(csolution.hasWestProject).toBeFalsy();
+        expect(csolution.hasWestProject()).toBeFalsy();
 
         const cdefaultPath = csolution.cbuildIdxFile?.topItem?.getValue('cdefault');
         const hasCdefault = !!cdefaultPath && fsUtils.fileExists(


### PR DESCRIPTION
## Fixes
<!-- List the GitHub issue(s) this PR resolves (e.g. #123) -->
- #312

## Changes
<!-- List the changes this PR introduces -->
- process onDidSetupCompleted Event in outline view and refresh it in case project type is 'West'

## Screenshots
<!-- Show UI changes with screenshots to ease UX/UI feedback: -->

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [ ] 🤖 This change is covered by unit tests (if applicable).
- [ ] 🤹 Manual testing has been performed (if necessary).
- [ ] 🛡️ Security impacts have been considered (if relevant).
- [ ] 📖 Documentation updates are complete (if required).
- [ ] 🧠 Third-party dependencies and TPIP updated (if required).
